### PR TITLE
better support localStorage emulations (e.g. Node module 'dom-storage')

### DIFF
--- a/src/92localstorage.js
+++ b/src/92localstorage.js
@@ -7,7 +7,7 @@
 var LS = alasql.engines.localStorage = function (){};
 
 LS.get = function(key) {
-	var s = localStorage[key];
+	var s = localStorage.getItem(key);
 	if(typeof s == "undefined") return;
 	var v = undefined;
 	try {
@@ -20,7 +20,7 @@ LS.get = function(key) {
 
 LS.set = function(key, value){
 	if(typeof value == 'undefined') localStorage.removeItem(key);
-	else localStorage[key] = JSON.stringify(value); 
+	else localStorage.setItem(key, JSON.stringify(value));
 }
 
 LS.createDatabase = function(lsdbid, args, ifnotexists, dbid, cb){
@@ -157,7 +157,7 @@ LS.intoTable = function(databaseid, tableid, value, cb) {
 	tb = tb.concat(value);
 	LS.set(lsdbid+'.'+tableid, tb);
 //	console.log(lsdbid+'.'+tableid, tb);
-//	console.log(localStorage[lsdbid+'.'+tableid]);
+//	console.log(localStorage.getItem(lsdbid+'.'+tableid));
 	if(cb) cb(res);
 	return res;
 };


### PR DESCRIPTION
...by using the official getter/setter methods of the W3C DOM Storage API. This allows us to persist AlaSQL databases in Node applications as following:

``` js
var DOMStorage = require("dom-storage")
global.localStorage = new DOMStorage("./app.json", { strict: false, ws: '' })

var alasql = require("alasql");
var db = new alasql.Database();

db.exec("CREATE localStorage DATABASE IF NOT EXISTS App");
db.exec("ATTACH localStorage DATABASE App");
db.exec("CREATE TABLE App.cities (city string, population number)");
db.exec("INSERT INTO App.cities VALUES ('Rome', 2863223), ('Paris', 2249975), ('Berlin', 3517424), ('Madrid', 3041579)");
```
