### PR TITLE
Include dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "example": "examples",
     "test": "test"
   },
+  "dependencies": {
+    "es6-promise": "2.1.1"
+  },
   "devDependencies": {
     "dom-storage":"2.0.1",
     "gulp":"3.8.11",


### PR DESCRIPTION
`require('es6-promise')` is called within the source, but es6-promise is not included as a dependency, so if you install alasql, you'll get a missing module error.

This fixes #214