### PR TITLE
Depend on xlsx NPM package instead of js-xlsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jison":"0.4.15",
     "lodash":"3.7.0",
     "xlsjs":"0.7.15",
-    "js-xlsx":"0.8.0"
+    "xlsx":"0.8.0"
     },
   "engines": [
     "node"


### PR DESCRIPTION
JS-xlsx NPM package is named ```xlsx```, not ```js-xlsx```.
(see https://github.com/SheetJS/js-xlsx#installation, https://www.npmjs.com/package/xlsx)

Having ```js-xlsx``` dependency causes NPM to fail while installing alasql:
![2015-05-29 14-38-02 banners and alerts](https://cloud.githubusercontent.com/assets/5237443/7881872/5e75839c-0610-11e5-8745-ce2977fb2843.png)