### PR TITLE
Fix running npm scripts on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/gulp && cd test && ../node_modules/.bin/mocha . --reporter dot",
-    "test:this": "./node_modules/.bin/gulp && cd test && ../node_modules/.bin/mocha ",
-    "test:only": "cd test && ../node_modules/.bin/mocha . --reporter dot",
+    "test": "gulp && cd test && mocha . --reporter dot",
+    "test:this": "gulp && cd test && mocha",
+    "test:only": "cd test && mocha . --reporter dot",
     "test:browser": "node test/browserTestRunner.js 7387",
-    "build": "./node_modules/.bin/gulp",
-    "build:jison": "./node_modules/.bin/gulp --jison && ./node_modules/.bin/gulp",
-    "build:watch": "./node_modules/.bin/gulp watch",
-    "bump": "./node_modules/.bin/mversion --no-prefix",
-    "uptodate": "./node_modules/.bin/npm-check && ./node_modules/.bin/npm-check -u",
+    "build": "gulp",
+    "build:jison": "gulp --jison && gulp",
+    "build:watch": "gulp watch",
+    "bump": "mversion --no-prefix",
+    "uptodate": "npm-check && npm-check -u",
     "release": "f='/TMP/alasql.tmp' && curl https://raw.githubusercontent.com/wiki/agershun/alasql/how-to-release.md > $f && sh $f ; rm $f",
-    "jison": "./node_modules/.bin/jison ./src/alasqlparser.jison -o ./src/alasqlparser.js"
+    "jison": "jison ./src/alasqlparser.jison -o ./src/alasqlparser.js"
   },
   "dependencies": {
     "dom-storage": "^2.0.1",


### PR DESCRIPTION
When i try for example ```npm test``` for running tests i got this error on windows 
```
> npm test

alasql@0.2.2 test C:\Work\alasql
gulp && cd test && ../node_modules/.bin/mocha . --reporter dot

[20:58:03] Using gulpfile C:\Work\alasql\gulpfile.js
[20:58:03] Starting 'js-merge'...
[20:58:03] Starting 'js-merge-worker'...
[20:58:03] Starting 'plugin-prolog'...
[20:58:03] Finished 'plugin-prolog' after 781 us
[20:58:03] Starting 'plugin-plugins'...
[20:58:03] Finished 'plugin-plugins' after 1.18 ms
[20:58:03] Finished 'js-merge-worker' after 187 ms
[20:58:13] Finished 'js-merge' after 10 s
[20:58:13] Starting 'default'...
[20:58:13] Finished 'default' after 5.6 us
'..' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! Test failed.  See above for more details.
```

> Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix.

This PR fix that. See npm doc for more info https://docs.npmjs.com/cli/run-script
