### PR TITLE
Include check constraint names in violation errors

### DIFF
--- a/src/23table.js
+++ b/src/23table.js
@@ -26,7 +26,7 @@ var Table = alasql.Table = function(params){
 	this.identities = {};
 
 	// Step 5: checkfn...
-	this.checkfn = [];
+	this.checks = [];
 	this.checkfns = []; // For restore... to be done...
 
 	// Step 6: INSERT/DELETE/UPDATE


### PR DESCRIPTION
Instead of throwing a generic "Violation of CHECK constraint", a violation now throws "Violation of CHECK constraint {constraint_name}".