### PR TITLE
Allow unknown functions to be defined on alasql.fn afterwards

### DIFF
--- a/src/55functions.js
+++ b/src/55functions.js
@@ -66,7 +66,23 @@ yy.FuncValue.prototype.toJS = function(context, tableid, defcols) {
 	var s = '';
     var funcid = this.funcid;
 	// IF this is standard compile functions
-	if(alasql.fn[funcid]) {
+	if(!alasql.fn[funcid] && alasql.stdlib[funcid.toUpperCase()]) {
+		if(this.args && this.args.length > 0) {
+			s += alasql.stdlib[funcid.toUpperCase()].apply(this, this.args.map(function(arg) {return arg.toJS(context, tableid)}));
+		} else {
+			s += alasql.stdlib[funcid.toUpperCase()]();
+		}
+	} else if(!alasql.fn[funcid] && alasql.stdfn[funcid.toUpperCase()]) {
+		if(this.newid) s+= 'new ';
+		s += 'alasql.stdfn.'+this.funcid.toUpperCase()+'(';
+//		if(this.args) s += this.args.toJS(context, tableid);
+		if(this.args && this.args.length > 0) {
+			s += this.args.map(function(arg){
+				return arg.toJS(context, tableid, defcols);
+			}).join(',');
+		};
+		s += ')';		
+	} else {
 	// This is user-defined run-time function
 	// TODO arguments!!!
 //		var s = '';
@@ -79,24 +95,6 @@ yy.FuncValue.prototype.toJS = function(context, tableid, defcols) {
 			}).join(',');
 		};
 		s += ')';
-	} else if(alasql.stdlib[funcid.toUpperCase()]) {
-		if(this.args && this.args.length > 0) {
-			s += alasql.stdlib[funcid.toUpperCase()].apply(this, this.args.map(function(arg) {return arg.toJS(context, tableid)}));
-		} else {
-			s += alasql.stdlib[funcid.toUpperCase()]();
-		}
-	} else if(alasql.stdfn[funcid.toUpperCase()]) {
-		if(this.newid) s+= 'new ';
-		s += 'alasql.stdfn.'+this.funcid.toUpperCase()+'(';
-//		if(this.args) s += this.args.toJS(context, tableid);
-		if(this.args && this.args.length > 0) {
-			s += this.args.map(function(arg){
-				return arg.toJS(context, tableid, defcols);
-			}).join(',');
-		};
-		s += ')';		
-	} else {
-		// Aggregator
 	}
 //console.log('userfn:',s,this);
 


### PR DESCRIPTION
Right now, unknown SQL function calls are transpiled to empty strings, which results in cryptic errors. This PR solves this by transpiling unknown_function(a, b) to alasql.fn.unknown_function(a, b) regardless of whether alasql.fn.unknown_function is actually defined, while still respecting alasql's stdfns. This also allows folks to define the implementation of functions after the fact, which I require in one of my projects.