### PR TITLE
Fix hasIndexedDB

### DIFF
--- a/src/15utility.js
+++ b/src/15utility.js
@@ -253,7 +253,7 @@ utils.isCordova = (function(){
 })();
 
 utils.hasIndexedDB = (function(){
-  return (typeof utils.global.indexedDB !== 'undefined');
+  return !!utils.global.indexedDB;
 })();
 
 


### PR DESCRIPTION
It seems that `window.indexedDB` is `null` when it is not available. I've faced a problem alasql raises runtime error on ios8+chrome and found it is caused since `(typeof utils.global.indexedDB !== 'undefined');` returns true when `window.indexedDB` is `null`.
