### PR TITLE
Conflate null and undefined

### DIFF
--- a/src/50expression.js
+++ b/src/50expression.js
@@ -364,9 +364,9 @@ yy.Op.prototype.toJS = function(context,tableid,defcols) {
 	if(this.op === 'IS') {
 		s = 	''
 				+ '('
-				+	'(typeof ' + leftJS()  + "==='undefined')"
+				+	'(' + leftJS()  + "==null)"
 				+	" === "
-				+	'(typeof ' + rightJS() + "==='undefined')"
+				+	'(' + rightJS() + "==null)"
 				+ ')';
 	}
 
@@ -585,7 +585,7 @@ yy.Op.prototype.toJS = function(context,tableid,defcols) {
 	}
 	else {
 		return '(' + declareRefs + ', '
-			+ 'y.some(function(e){return e === void 0}) ? void 0 : ' + expr + ')' 
+			+ 'y.some(function(e){return e == null}) ? void 0 : ' + expr + ')' 
 	}
 }
 


### PR DESCRIPTION
Like undefined, null should be treated as NULL.