### PR TITLE
Fix #727 - INTO CSV caused regex error with empty quote

### DIFF
--- a/src/830into.js
+++ b/src/830into.js
@@ -203,7 +203,8 @@ alasql.into.CSV = function(filename, opts, data, columns, cb) {
 	data.forEach(function(d){
 		s += columns.map(function(col){
 			var s = d[col.columnid];
-			s = (s+"").replace(new RegExp('\\'+opt.quote,"g"),'""');
+                        var quotereg = (opt.quote === '') ? '' : '\\' + opt.quote;
+			s = (s+"").replace(new RegExp(quotereg,"g"),'""');
 //			if((s+"").indexOf(opt.separator) > -1 || (s+"").indexOf(opt.quote) > -1) s = opt.quote + s + opt.quote; 
       
       //Excel 2013 needs quotes around strings - thanks for _not_ complying with RFC for CSV 

--- a/src/830into.js
+++ b/src/830into.js
@@ -203,7 +203,7 @@ alasql.into.CSV = function(filename, opts, data, columns, cb) {
 	data.forEach(function(d){
 		s += columns.map(function(col){
 			var s = d[col.columnid];
-                        var quotereg = (opt.quote === '') ? '' : '\\' + opt.quote;
+			var quotereg = (opt.quote === '') ? '' : '\\' + opt.quote;
 			s = (s+"").replace(new RegExp(quotereg,"g"),'""');
 //			if((s+"").indexOf(opt.separator) > -1 || (s+"").indexOf(opt.quote) > -1) s = opt.quote + s + opt.quote; 
       

--- a/test/test727.js
+++ b/test/test727.js
@@ -1,7 +1,7 @@
 if(typeof exports === 'object') {
 	var assert = require("assert");
 	var alasql = require('..');
-        var fs = require("fs");
+	var fs = require("fs");
 }
 
 var test = '727'; // insert test file number
@@ -13,6 +13,6 @@ describe('Test '+test+' - INTO CSV', function() {
         });
 
 	it('With quote = \'\'', function(){
-                alasql("SELECT \"1\" INTO CSV('sdfsfd', {quote:''})");
+		alasql("SELECT \"1\" INTO CSV('sdfsfd', {quote:''})");
         });
 });

--- a/test/test727.js
+++ b/test/test727.js
@@ -1,0 +1,18 @@
+if(typeof exports === 'object') {
+	var assert = require("assert");
+	var alasql = require('..');
+        var fs = require("fs");
+}
+
+var test = '727'; // insert test file number
+
+describe('Test '+test+' - INTO CSV', function() {
+	
+	after(function(){
+		fs.unlink('sdfsfd.csv');
+        });
+
+	it('With quote = \'\'', function(){
+                alasql("SELECT \"1\" INTO CSV('sdfsfd', {quote:''})");
+        });
+});


### PR DESCRIPTION
This appears to resolve the bug but it sure would be weird to set the `quote` property to `''`.
