### PR TITLE
Remove implicit any in definition file

### DIFF
--- a/dist/alasql.d.ts
+++ b/dist/alasql.d.ts
@@ -66,7 +66,7 @@ declare namespace alaSQLSpace {
         options: AlaSQLOptions;
         error: Error;
         (sql: any, params?: any, cb?: AlaSQLCallback, scope?: any): any;
-        parse(sql): AlaSQLAST;
+        parse(sql: any): AlaSQLAST;
         promise(sql: any, params?: any): Thenable<any>;
         fn: userDefinedFunctionLookUp;
         aggr: userAggregatorLookUp;


### PR DESCRIPTION
Implicit any causes compiler errors if noImplicitAny flag is enabled.