### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ import alasql from 'alasql';   # meteor
 npm install -g alasql          # command line
 ```
 
-For the browser: include [alasql.min.js](http://cdn.jsdelivr.net/alasql/latest/alasql.min.js)  
+For the browser: include [alasql.min.js](https://cdn.jsdelivr.net/npm/alasql@latest/dist/alasql.min.js)  
 
 ```html
-<script src="http://cdn.jsdelivr.net/alasql/0.3/alasql.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/alasql@0.4.2/dist/alasql.min.js"></script>
 ```
 
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/alasql.

Feel free to ping me if you have any questions regarding this change.