### PR TITLE
Correct grammar of "Table/Column does not exist" error

### DIFF
--- a/src/424select.js
+++ b/src/424select.js
@@ -221,7 +221,7 @@ yy.Select.prototype.compileSelect1 = function(query, params) {
 				if (query.aliases[tbid] && query.aliases[tbid].type === 'table') {
 					if (!alasql.databases[dbid].tables[query.aliases[tbid].tableid]) {
 						//						console.log(query.database,tbid,query.aliases[tbid].tableid);
-						throw new Error("Table '" + tbid + "' does not exists in database");
+						throw new Error("Table '" + tbid + "' does not exist in database");
 					}
 					var columns =
 						alasql.databases[dbid].tables[query.aliases[tbid].tableid].columns;
@@ -234,7 +234,7 @@ yy.Select.prototype.compileSelect1 = function(query, params) {
 						var tcol = xcolumns[col.columnid];
 
 						if (undefined === tcol) {
-							throw new Error('Column does not exists: ' + col.columnid);
+							throw new Error('Column does not exist: ' + col.columnid);
 						}
 
 						var coldef = {

--- a/src/44defcols.js
+++ b/src/44defcols.js
@@ -22,7 +22,7 @@ yy.Select.prototype.compileDefCols = function(query, databaseid) {
 				//console.log(table);
 
 				if (undefined === table) {
-					throw new Error('Table does not exists: ' + fr.tableid);
+					throw new Error('Table does not exist: ' + fr.tableid);
 				}
 
 				if (table.columns) {

--- a/test/test232.js
+++ b/test/test232.js
@@ -27,7 +27,7 @@ describe('Test 232 Errors handling', function() {
 	it('3. Log error async', function(done) {
 		alasql('set errorlog on');
 		alasql('SELECT * FROM faultyName', [], function(data, err) {
-			assert(/^Table does not exists\:/.test(err.message));
+			assert(/^Table does not exist\:/.test(err.message));
 			done();
 		});
 	});
@@ -35,7 +35,7 @@ describe('Test 232 Errors handling', function() {
 	it('4. Log error sync', function() {
 		alasql('set errorlog on');
 		alasql('SELECT * FROM faultyName');
-		assert(/^Table does not exists\:/.test(alasql.error.message));
+		assert(/^Table does not exist\:/.test(alasql.error.message));
 		alasql('SELECT * FROM ?', [{a: 1}, {a: 2}]);
 		assert(!alasql.error);
 	});


### PR DESCRIPTION
This change is relatively superficial. No additional tests were required, though I had to edit some existing ones.

