### PR TITLE
Changed the error message when foreign key constraint fails

### DIFF
--- a/dist/alasql.js
+++ b/dist/alasql.js
@@ -12826,7 +12826,7 @@ yy.CreateTable.prototype.execute = function(databaseid, params, cb) {
 							'Foreign key "' +
 								r[col.columnid] +
 								'" is not found in table ' +
-								fktable.tableid
+								fk
 						);
 					}
 					return true;
@@ -12908,7 +12908,7 @@ yy.CreateTable.prototype.execute = function(databaseid, params, cb) {
 						'Foreign key "' +
 							r[col.columnid] +
 							'" is not found in table ' +
-							fktable.tableid
+							fk
 					);
 				}
 				return true;

--- a/src/60createtable.js
+++ b/src/60createtable.js
@@ -207,12 +207,13 @@ yy.CreateTable.prototype.execute = function(databaseid, params, cb) {
 					var addr = fktable.pk.onrightfn(rr);
 					//						console.log(r, rr, addr);
 					//						console.log(fktable.uniqs[fktable.pk.hh][addr]);
-					if (!fktable.uniqs[fktable.pk.hh][addr]) {
+					if (!fktable.uniqs[fktable.pk.hh][addr]) {      
 						throw new Error(
-							'Foreign key "' +
-								r[col.columnid] +
-								'" is not found in table ' +
-								fktable.tableid
+// 							'Foreign key "' +
+// 								r[col.columnid] +
+// 								'" is not found in table ' +
+// 								fktable.tableid
+							'Foreign key violation'              //changed error message
 						);
 					}
 					return true;
@@ -300,10 +301,12 @@ yy.CreateTable.prototype.execute = function(databaseid, params, cb) {
 				if (!fktable.uniqs[fktable.pk.hh][addr]) {
 					//console.log(228,table,col,fk);
 					throw new Error(
-						'Foreign key "' +
-							r[col.columnid] +
-							'" is not found in table ' +
-							fktable.tableid
+// 						'Foreign key "' +
+// 							r[col.columnid] +
+// 							'" is not found in table ' +
+// 							fktable.tableid
+						'Foreign key violation'  //changed error message
+					
 					);
 				}
 				return true;


### PR DESCRIPTION
changed the error message when foreign key constraint falis, from "undefined" table name to the actual table name,in the file alasql.js.
This is with respect to the issue #1009 


