### PR TITLE
fixed duplicate key + engines syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
     "tabletop": "^1.5.2",
     "uglify-js": "^3.3.7"
   },
-  "engines": [
-    "node"
-  ],
+  "engines": {
+    "node": "*"
+  },
   "repository": {
     "type": "git",
     "url": "http://github.com/agershun/alasql.git"
@@ -102,6 +102,5 @@
       "ipad/4..latest",
       "android-browser/4..latest"
     ]
-  },
-  "typings": "./dist/alasql.d.ts"
+  }
 }


### PR DESCRIPTION
My editor was complaining about two errors in package.json:

* `typings` key was duplicated.
* `engines` key had an invalid value: array instead of object. As I don't know what the minimum supported node version is, I put `"*"`.


