### PR TITLE
fix QUART/MEDIAN/MIN/MAX on number/date/string

### DIFF
--- a/dist/alasql-worker.js
+++ b/dist/alasql-worker.js
@@ -1,7 +1,7 @@
-//! AlaSQL v0.5.3 | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
+//! AlaSQL v0.5.3-develop-8b2fda7fundefined | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
 /*
 @module alasql
-@version 0.5.3
+@version 0.5.3-develop-8b2fda7fundefined
 
 AlaSQL - JavaScript SQL database
 © 2014-2016	Andrey Gershun & Mathias Rangel Wulff

--- a/dist/alasql-worker.min.js
+++ b/dist/alasql-worker.min.js
@@ -1,4 +1,4 @@
-//! AlaSQL v0.5.3 | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
+//! AlaSQL v0.5.3-develop-8b2fda7fundefined | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
 !(function(r, e) {
 	'function' == typeof define && define.amd
 		? define([], e)

--- a/dist/alasql.fs.js
+++ b/dist/alasql.fs.js
@@ -1,7 +1,7 @@
-//! AlaSQL v0.5.3 | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
+//! AlaSQL v0.5.3-develop-8b2fda7fundefined | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
 /*
 @module alasql
-@version 0.5.3
+@version 0.5.3-develop-8b2fda7fundefined
 
 AlaSQL - JavaScript SQL database
 © 2014-2016	Andrey Gershun & Mathias Rangel Wulff
@@ -143,7 +143,7 @@ SOFTWARE.
 	Current version of alasql 
  	@constant {string} 
 */
-	alasql.version = '0.5.3';
+	alasql.version = '0.5.3-develop-8b2fda7fundefined';
 
 	/**
 	Debug flag
@@ -29513,8 +29513,8 @@ var __dirname = '';
 						action = table[state] && table[state][symbol];
 					}
 
-					_handle_error: // handle parse error
-					if (typeof action === 'undefined' || !action.length || !action[0]) {
+					// handle parse error
+					_handle_error: if (typeof action === 'undefined' || !action.length || !action[0]) {
 						var error_rule_depth;
 						var errStr = '';
 
@@ -37719,9 +37719,13 @@ var __dirname = '';
 						} else if (col.aggregatorid === 'ARRAY') {
 							return pre + "g['" + colas + "'].push(" + colexp + ');' + post;
 						} else if (col.aggregatorid === 'MIN') {
-							return pre + "g['" + colas + "']=Math.min(g['" + colas + "']," + colexp + ');' + post;
+							return (
+								pre + 'if ((y=' + colexp + ") < g['" + colas + "']) g['" + colas + "'] = y;" + post
+							);
 						} else if (col.aggregatorid === 'MAX') {
-							return pre + "g['" + colas + "']=Math.max(g['" + colas + "']," + colexp + ');' + post;
+							return (
+								pre + 'if ((y=' + colexp + ") > g['" + colas + "']) g['" + colas + "'] = y;" + post
+							);
 						} else if (col.aggregatorid === 'FIRST') {
 							return '';
 						} else if (col.aggregatorid === 'LAST') {
@@ -40239,11 +40243,19 @@ if(false) {
 	};
 
 	stdlib.MAX = stdlib.GREATEST = function() {
-		return 'Math.max(' + Array.prototype.join.call(arguments, ',') + ')';
+		return (
+			'[' +
+			Array.prototype.join.call(arguments, ',') +
+			'].reduce(function (a, b) { return a > b ? a : b; })'
+		);
 	};
 
 	stdlib.MIN = stdlib.LEAST = function() {
-		return 'Math.min(' + Array.prototype.join.call(arguments, ',') + ')';
+		return (
+			'[' +
+			Array.prototype.join.call(arguments, ',') +
+			'].reduce(function (a, b) { return a < b ? a : b; })'
+		);
 	};
 
 	stdlib.SUBSTRING = stdlib.SUBSTR = stdlib.MID = function(a, b, c) {
@@ -40347,10 +40359,22 @@ if(false) {
 				return s;
 			}
 
-			var r = s.sort();
+			var r = s.sort(function(a, b) {
+				if (a === b) {
+					return 0;
+				}
+				if (a > b) {
+					return 1;
+				}
+				return -1;
+			});
 			var p = (r.length + 1) / 2;
 			if (Number.isInteger(p)) {
 				return r[p - 1];
+			}
+
+			if (typeof r[Math.floor(p - 1)] !== 'number') {
+				return r[Math.floor(p - 1)];
 			}
 
 			return (r[Math.floor(p - 1)] + r[Math.ceil(p - 1)]) / 2;
@@ -40375,7 +40399,15 @@ if(false) {
 			}
 
 			nth = !nth ? 1 : nth;
-			var r = s.sort();
+			var r = s.sort(function(a, b) {
+				if (a === b) {
+					return 0;
+				}
+				if (a > b) {
+					return 1;
+				}
+				return -1;
+			});
 			var p = (nth * (r.length + 1)) / 4;
 			if (Number.isInteger(p)) {
 				return r[p - 1]; //Integer value

--- a/dist/alasql.min.js
+++ b/dist/alasql.min.js
@@ -1,4 +1,4 @@
-//! AlaSQL v0.5.3 | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
+//! AlaSQL v0.5.3-develop-8b2fda7fundefined | © 2014-2018 Andrey Gershun & Mathias Rangel Wulff | License: MIT
 'use strict';
 !(function(e, t) {
 	'function' == typeof define && define.amd
@@ -33,7 +33,7 @@
 					  ])[1])),
 			  gi.exec(e, t, r, n));
 	};
-	(gi.version = '0.5.3'), (gi.debug = void 0);
+	(gi.version = '0.5.3-develop-8b2fda7fundefined'), (gi.debug = void 0);
 	function W() {
 		return null;
 	}
@@ -33695,9 +33695,9 @@
 										: 'ARRAY' === e.aggregatorid
 										? n + "g['" + t + "'].push(" + r + ');' + a
 										: 'MIN' === e.aggregatorid
-										? n + "g['" + t + "']=Math.min(g['" + t + "']," + r + ');' + a
+										? n + 'if ((y=' + r + ") < g['" + t + "']) g['" + t + "'] = y;" + a
 										: 'MAX' === e.aggregatorid
-										? n + "g['" + t + "']=Math.max(g['" + t + "']," + r + ');' + a
+										? n + 'if ((y=' + r + ") > g['" + t + "']) g['" + t + "'] = y;" + a
 										: 'FIRST' === e.aggregatorid
 										? ''
 										: 'LAST' === e.aggregatorid
@@ -35046,10 +35046,18 @@
 			return n(e, 'y.replace(/[ ]+$/,"")');
 		}),
 		(V.MAX = V.GREATEST = function() {
-			return 'Math.max(' + Array.prototype.join.call(arguments, ',') + ')';
+			return (
+				'[' +
+				Array.prototype.join.call(arguments, ',') +
+				'].reduce(function (a, b) { return a > b ? a : b; })'
+			);
 		}),
 		(V.MIN = V.LEAST = function() {
-			return 'Math.min(' + Array.prototype.join.call(arguments, ',') + ')';
+			return (
+				'[' +
+				Array.prototype.join.call(arguments, ',') +
+				'].reduce(function (a, b) { return a < b ? a : b; })'
+			);
 		}),
 		(V.SUBSTRING = V.SUBSTR = V.MID = function(e, t, r) {
 			return 2 == arguments.length
@@ -35107,16 +35115,24 @@
 			if (2 === r) return null !== e && t.push(e), t;
 			if (1 === r) return null === e ? [] : [e];
 			if (!t.length) return t;
-			var n = t.sort(),
+			var n = t.sort(function(e, t) {
+					return e === t ? 0 : t < e ? 1 : -1;
+				}),
 				a = (n.length + 1) / 2;
-			return Number.isInteger(a) ? n[a - 1] : (n[Math.floor(a - 1)] + n[Math.ceil(a - 1)]) / 2;
+			return Number.isInteger(a)
+				? n[a - 1]
+				: 'number' != typeof n[Math.floor(a - 1)]
+				? n[Math.floor(a - 1)]
+				: (n[Math.floor(a - 1)] + n[Math.ceil(a - 1)]) / 2;
 		}),
 		(gi.aggr.QUART = function(e, t, r, n) {
 			if (2 === r) return null !== e && t.push(e), t;
 			if (1 === r) return null === e ? [] : [e];
 			if (!t.length) return t;
 			n = n || 1;
-			var a = t.sort(),
+			var a = t.sort(function(e, t) {
+					return e === t ? 0 : t < e ? 1 : -1;
+				}),
 				s = (n * (a.length + 1)) / 4;
 			return Number.isInteger(s) ? a[s - 1] : a[Math.floor(s)];
 		}),
@@ -38151,11 +38167,8 @@
 												'number' == a ? (s = 'Number') : 'date' == a && (s = 'Date');
 												'money' == a ||
 													'number' == a ||
-														'date' == a ||
-															(b.types &&
-																b.types[a] &&
-																b.types[a].typestyle &&
-																b.types[a].typestyle),
+													'date' == a ||
+													(b.types && b.types[a] && b.types[a].typestyle && b.types[a].typestyle),
 													(h += '<Cell ');
 												var i = {};
 												void 0 !== r.style &&

--- a/src/423groupby.js
+++ b/src/423groupby.js
@@ -52,7 +52,7 @@ if(false) {
 //			console.log(colid,'ok');
 		} else {
 //			if(colid.indexOf())
-//			console.log(colid,'bad');	
+//			console.log(colid,'bad');
 			var tmpid = 'default';
 			if(query.sources.length > 0) tmpid = query.sources[0].alias;
 //			console.log(new yy.Column({columnid:colid}).toJS('p',query.sources[0].alias));
@@ -126,12 +126,7 @@ if(false) {
 			aft2 = '';
 
 		if (typeof query.groupStar !== 'undefined') {
-			aft2 +=
-				"for(var f in p['" +
-				query.groupStar +
-				"']) {g[f]=p['" +
-				query.groupStar +
-				"'][f];};";
+			aft2 += "for(var f in p['" + query.groupStar + "']) {g[f]=p['" + query.groupStar + "'][f];};";
 		}
 
 		/*
@@ -150,13 +145,7 @@ if(false) {
 				if (col instanceof yy.AggrValue) {
 					if (col.distinct) {
 						aft +=
-							",g['$$_VALUES_" +
-							colas +
-							"']={},g['$$_VALUES_" +
-							colas +
-							"'][" +
-							colexp +
-							']=true';
+							",g['$$_VALUES_" + colas + "']={},g['$$_VALUES_" + colas + "'][" + colexp + ']=true';
 					}
 					if (col.aggregatorid === 'SUM') {
 						return "'" + colas + "':(" + colexp + ')||0,';
@@ -211,15 +200,7 @@ if(false) {
 
 						//					return "'"+colas+'\':alasql.aggr[\''+col.funcid+'\']('+colexp+',undefined,(acc={}),1),'
 						//					+'\'__REDUCE__'+colas+'\':acc,';
-						return (
-							"'" +
-							colas +
-							"':alasql.aggr['" +
-							col.funcid +
-							"'](" +
-							colexp +
-							',undefined,1),'
-						);
+						return "'" + colas + "':alasql.aggr['" + col.funcid + "'](" + colexp + ',undefined,1),';
 					}
 					return '';
 				}
@@ -245,18 +226,18 @@ if(false) {
 	//			if(f.constructor.name == 'LiteralValue') return '';
 
 
-			if (col instanceof yy.AggrValue) { 
-				if (col.aggregatorid == 'SUM') { srg.push("'"+col.as+'\':0'); }//f.field.arguments[0].toJS(); 	
+			if (col instanceof yy.AggrValue) {
+				if (col.aggregatorid == 'SUM') { srg.push("'"+col.as+'\':0'); }//f.field.arguments[0].toJS();
 				else if(col.aggregatorid == 'COUNT') {srg.push( "'"+col.as+'\':0'); }
 				else if(col.aggregatorid == 'MIN') { srg.push( "'"+col.as+'\':Infinity'); }
 				else if(col.aggregatorid == 'MAX') { srg.push( "'"+col.as+'\':-Infinity'); }
 	//			else if(col.aggregatorid == 'AVG') { srg.push(col.as+':0'); }
-	//				return 'group.'+f.name.value+'=+(+group.'+f.name.value+'||0)+'+f.field.arguments[0].toJS('rec','')+';'; //f.field.arguments[0].toJS(); 	
+	//				return 'group.'+f.name.value+'=+(+group.'+f.name.value+'||0)+'+f.field.arguments[0].toJS('rec','')+';'; //f.field.arguments[0].toJS();
 			};
 
 		});
 
-	
+
 
 	/***************** /
 
@@ -319,41 +300,17 @@ if(false) {
 						if (col.expression.columnid === '*') {
 							return pre + "g['" + colas + "']++;" + post;
 						} else {
-							return (
-								pre +
-								'if(typeof ' +
-								colexp +
-								'!="undefined") g[\'' +
-								colas +
-								"']++;" +
-								post
-							);
+							return pre + 'if(typeof ' + colexp + '!="undefined") g[\'' + colas + "']++;" + post;
 						}
 					} else if (col.aggregatorid === 'ARRAY') {
 						return pre + "g['" + colas + "'].push(" + colexp + ');' + post;
 					} else if (col.aggregatorid === 'MIN') {
 						return (
-							pre +
-							"g['" +
-							colas +
-							"']=Math.min(g['" +
-							colas +
-							"']," +
-							colexp +
-							');' +
-							post
+							pre + 'if ((y=' + colexp + ") < g['" + colas + "']) g['" + colas + "'] = y;" + post
 						);
 					} else if (col.aggregatorid === 'MAX') {
 						return (
-							pre +
-							"g['" +
-							colas +
-							"']=Math.max(g['" +
-							colas +
-							"']," +
-							colexp +
-							');' +
-							post
+							pre + 'if ((y=' + colexp + ") > g['" + colas + "']) g['" + colas + "'] = y;" + post
 						);
 					} else if (col.aggregatorid === 'FIRST') {
 						return '';
@@ -383,16 +340,7 @@ if(false) {
 						//					 }
 						//			else if(col.aggregatorid == 'AVG') { srg.push(colas+':0'); }
 					} else if (col.aggregatorid === 'AGGR') {
-						return (
-							'' +
-							pre +
-							"g['" +
-							colas +
-							"']=" +
-							col.expression.toJS('g', -1) +
-							';' +
-							post
-						);
+						return '' + pre + "g['" + colas + "']=" + col.expression.toJS('g', -1) + ';' + post;
 					} else if (col.aggregatorid === 'REDUCE') {
 						return (
 							'' +

--- a/src/55functions.js
+++ b/src/55functions.js
@@ -127,14 +127,14 @@ yy.FuncValue.prototype.toJS = function(context, tableid, defcols) {
 */
 
 /*/*
-// 
+//
 // SQL FUNCTIONS COMPILERS
 // Based on SQLite functions
 
 // IMPORTANT: These are compiled functions
 
 //alasql.fn = {}; // Keep for compatibility
-//alasql.userlib = alasql.fn; 
+//alasql.userlib = alasql.fn;
 */
 
 var stdlib = (alasql.stdlib = {});
@@ -193,11 +193,19 @@ stdlib.RTRIM = function(s) {
 };
 
 stdlib.MAX = stdlib.GREATEST = function() {
-	return 'Math.max(' + Array.prototype.join.call(arguments, ',') + ')';
+	return (
+		'[' +
+		Array.prototype.join.call(arguments, ',') +
+		'].reduce(function (a, b) { return a > b ? a : b; })'
+	);
 };
 
 stdlib.MIN = stdlib.LEAST = function() {
-	return 'Math.min(' + Array.prototype.join.call(arguments, ',') + ')';
+	return (
+		'[' +
+		Array.prototype.join.call(arguments, ',') +
+		'].reduce(function (a, b) { return a < b ? a : b; })'
+	);
 };
 
 stdlib.SUBSTRING = stdlib.SUBSTR = stdlib.MID = function(a, b, c) {
@@ -302,10 +310,22 @@ alasql.aggr.MEDIAN = function(v, s, stage) {
 			return s;
 		}
 
-		var r = s.sort();
+		var r = s.sort(function(a, b) {
+			if (a === b) {
+				return 0;
+			}
+			if (a > b) {
+				return 1;
+			}
+			return -1;
+		});
 		var p = (r.length + 1) / 2;
 		if (Number.isInteger(p)) {
 			return r[p - 1];
+		}
+
+		if (typeof r[Math.floor(p - 1)] !== 'number') {
+			return r[Math.floor(p - 1)];
 		}
 
 		return (r[Math.floor(p - 1)] + r[Math.ceil(p - 1)]) / 2;
@@ -330,7 +350,15 @@ alasql.aggr.QUART = function(v, s, stage, nth) {
 		}
 
 		nth = !nth ? 1 : nth;
-		var r = s.sort();
+		var r = s.sort(function(a, b) {
+			if (a === b) {
+				return 0;
+			}
+			if (a > b) {
+				return 1;
+			}
+			return -1;
+		});
 		var p = (nth * (r.length + 1)) / 4;
 		if (Number.isInteger(p)) {
 			return r[p - 1]; //Integer value

--- a/test/test415.js
+++ b/test/test415.js
@@ -28,7 +28,7 @@ describe('Test ' + test + ' Aggregators', function() {
 		//    console.log(res1);
 
 		var res = alasql('SELECT MEDIAN(a) AS medparam FROM ?', [data]);
-		assert.deepEqual(res, [{medparam: 5499}]);
+		assert.deepEqual(res, [{medparam: 5000}]);
 
 		done();
 	});
@@ -39,15 +39,15 @@ describe('Test ' + test + ' Aggregators', function() {
 		assert.deepEqual(res, [{'MEDIAN(a)': 2, 'STDEV(a)': 1, 'SQRT(VAR(a))': 1}]);
 	});
 
-	it.skip('3. Test', function(done) {
+	it('3. Test', function(done) {
 		var resultSet = [
 			{_date: new Date('01.01.2016'), selectedChem: 1},
 			{_date: new Date('01.01.2015'), selectedChem: 2},
-			{_date: new Date('01.10.2015'), selectedChem: 3},
-			{_date: new Date('10.10.2015'), selectedChem: 4},
+			{_date: new Date('10.10.2015'), selectedChem: 3},
+			{_date: new Date('01.10.2015'), selectedChem: 4},
 		];
 		var res = alasql(
-			'SELECT count(1) AS ct, min(_date) AS minDate, max(_date) AS maxDate, min(selectedChem) AS minparam, max(selectedChem) AS maxparam, AVG(selectedChem) AS avgparam, MEDIAN(selectedChem) AS medparam, STDEV(selectedChem) AS sdevparam FROM ? WHERE selectedChem is not null AND selectedChem != -9999 ORDER BY _date',
+			'SELECT count(1) AS ct, min(_date) AS minDate, max(_date) AS maxDate, MEDIAN(_date) AS medDate, min(selectedChem) AS minparam, max(selectedChem) AS maxparam, AVG(selectedChem) AS avgparam, MEDIAN(selectedChem) AS medparam, STDEV(selectedChem) AS sdevparam FROM ? WHERE selectedChem is not null AND selectedChem != -9999 ORDER BY _date',
 			[resultSet]
 		);
 		//console.log(res);
@@ -55,34 +55,36 @@ describe('Test ' + test + ' Aggregators', function() {
 		assert.deepEqual(res, [
 			{
 				ct: 4,
-				minDate: 1420059600000,
-				maxDate: 1451595600000,
+				minDate: new Date('01.01.2015'),
+				maxDate: new Date('01.01.2016'),
+				medDate: new Date('01.10.2015'),
 				minparam: 1,
 				maxparam: 4,
 				avgparam: 2.5,
-				medparam: 3,
+				medparam: 2.5,
 				sdevparam: 1.2909944487358056,
 			},
 		]);
 		done();
 	});
 
-	it.skip('4. Test', function() {
+	it('4. Test', function() {
 		var resultSet = [
 			{_date: new Date('01.01.2016'), selectedChem: 1},
 			{_date: new Date('01.01.2015'), selectedChem: 2},
-			{_date: new Date('01.10.2015'), selectedChem: 3},
-			{_date: new Date('10.10.2015'), selectedChem: undefined},
+			{_date: new Date('10.10.2015'), selectedChem: 3},
+			{_date: new Date('01.10.2015'), selectedChem: undefined},
 		];
 		var res = alasql(
-			'SELECT count(1) AS ct, min(_date) AS minDate, max(_date) AS maxDate, min(selectedChem) AS minparam, max(selectedChem) AS maxparam, AVG(selectedChem) AS avgparam, MEDIAN(selectedChem) AS medparam, STDEV(selectedChem) AS sdevparam FROM ? WHERE selectedChem is not null AND selectedChem != -9999 ORDER BY _date',
+			'SELECT count(1) AS ct, min(_date) AS minDate, max(_date) AS maxDate, MEDIAN(_date) AS medDate, min(selectedChem) AS minparam, max(selectedChem) AS maxparam, AVG(selectedChem) AS avgparam, MEDIAN(selectedChem) AS medparam, STDEV(selectedChem) AS sdevparam FROM ? WHERE selectedChem is not null AND selectedChem != -9999 ORDER BY _date',
 			[resultSet]
 		);
 		assert.deepEqual(res, [
 			{
 				ct: 3,
-				minDate: 1420059600000,
-				maxDate: 1451595600000,
+				minDate: new Date('01.01.2015'),
+				maxDate: new Date('01.01.2016'),
+				medDate: new Date('10.10.2015'),
 				minparam: 1,
 				maxparam: 3,
 				avgparam: 2,
@@ -90,13 +92,28 @@ describe('Test ' + test + ' Aggregators', function() {
 				sdevparam: 1,
 			},
 		]);
-
-		//    assert.deepEqual(res,[ { 'MEDIAN(a)': 2, 'STDEV(a)': 1, 'SQRT(VAR(a))': 1 } ]);
 	});
 
 	it('4. Quatiles', function() {
-		var data = [{a: 2}, {a: 3}, {a: 4}, {a: 5}, {a: 6}, {a: 7}, {a: 8}, {a: 8}];
+		var data = [{a: 2}, {a: 3}, {a: 4}, {a: 5}, {a: 6}, {a: 7}, {a: 8}, {a: 8}, {a: 10}, {a: 10}];
 		var res = alasql('SELECT QUART(a), QUART2(a), QUART3(a) FROM ?', [data]);
-		assert.deepEqual(res, [{'QUART(a)': 4, 'QUART2(a)': 6, 'QUART3(a)': 8}]);
+		assert.deepEqual(res, [{'QUART(a)': 4, 'QUART2(a)': 7, 'QUART3(a)': 10}]);
+	});
+
+	it('5. GREATEST/LEAST', function() {
+		var res = alasql(
+			'SELECT LEAST(3, 12, 34, 8, 25) AS numL, GREATEST(3, 12, 34, 8, 25) AS numG, LEAST("w3", "mmco", "a") AS strL, GREATEST("w3", "mmco", "a") AS strG'
+		);
+		assert.deepEqual(res, [{numL: 3, numG: 34, strL: 'a', strG: 'w3'}]);
+
+		var data = [
+			{a: 1, b: 4},
+			{a: 5, b: 3},
+		];
+		res = alasql('SELECT GREATEST(a, b) AS g, LEAST(a, b) AS l FROM ?', [data]);
+		assert.deepEqual(res, [
+			{g: 4, l: 1},
+			{g: 5, l: 3},
+		]);
 	});
 });


### PR DESCRIPTION
Fix MIN/MAX and GREATEST/LEAST to work on date and string by actively compare with `<` and `>` instead of `Math.min` and `Math.max`. This is commonly supported by other SQL engine: https://www.w3resource.com/sql/aggregate-functions/min-function.php
Currently, `MIN/MAX` works for Date but the data type changes to number, which is not what user would expect.


Fix QUART/MEDIAN to use custom comparator with `<` and `>`. When comparator is not supplied, Javascript coerce arguments to string:
>If omitted, the array elements are converted to strings, then sorted according to each character's Unicode code point value.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort



Enabled skipped tests on these functions and update tests for new and correct behaviors (for example, median of numbers between 1 and 10000 should be 5000 not 5499.) add test from #104

p.s. some files got auto-formatted, specifically for `423groupby.js`, I only changed 'MIN' and 'MAX' implementation.

closes #411 

