### PR TITLE
Fix tests for node 12+

### DIFF
--- a/test/test046.js
+++ b/test/test046.js
@@ -37,18 +37,31 @@ describe('Test 046', function() {
 		});
 
 		it('queryArrayOfArrays()', function(done) {
-			var res = alasql('SELECT MATRIX [1] AS 0,[1]+[2] AS [1] FROM ? d WHERE [0]>2016', [
-				data,
-			]);
-			assert.deepEqual([[4, 6], [5, 8], [6, 9]], res);
+			var res = alasql('SELECT MATRIX [1] AS 0,[1]+[2] AS [1] FROM ? d WHERE [0]>2016', [data]);
+			assert.deepEqual(
+				[
+					[4, 6],
+					[5, 8],
+					[6, 9],
+				],
+				res
+			);
 			done();
 		});
 
 		it('queryArrayOfArrays and filter()', function(done) {
 			var res1 = alasql('SELECT * FROM ? d WHERE [0]>2016', [data]);
-			var res2 = data.filter(function(a) {
-				return a[0] > 2016;
-			});
+			var res2 = data
+				.filter(function(a) {
+					return a[0] > 2016;
+				})
+				.map(function(d) {
+					var res = {};
+					for (var i = 0; i < d.length; i++) {
+						res[i] = d[i];
+					}
+					return res;
+				});
 			assert.deepEqual(res1, res2);
 			done();
 		});
@@ -61,7 +74,10 @@ describe('Test 046', function() {
 				GROUP BY [2] ',
 				[data]
 			);
-			assert.deepEqual(res, [[2, 4], [3, 11]]);
+			assert.deepEqual(res, [
+				[2, 4],
+				[3, 11],
+			]);
 			done();
 		});
 	});

--- a/test/test433.js
+++ b/test/test433.js
@@ -11,13 +11,20 @@ describe('Test ' + test + ' - read csv from variable', function() {
 			'A,B,C\n10,20,30\n20,30,40',
 		]);
 
-		assert.deepEqual(res, [{A: 10, B: 20, C: 30}, {A: 20, B: 30, C: 40}]);
+		assert.deepEqual(res, [
+			{A: 10, B: 20, C: 30},
+			{A: 20, B: 30, C: 40},
+		]);
 	});
 
 	it('works from csv variable - async', function(done) {
 		var sql = 'SELECT * FROM CSV(?, {"headers": false, "fromString": true})';
 		alasql(sql, ['a,b,c\nd,e,f\none,two,three\n'], function(res) {
-			assert.deepEqual(res, [['a', 'b', 'c'], ['d', 'e', 'f'], ['one', 'two', 'three']]);
+			assert.deepEqual(res, [
+				{'0': 'a', '1': 'b', '2': 'c'},
+				{'0': 'd', '1': 'e', '2': 'f'},
+				{'0': 'one', '1': 'two', '2': 'three'},
+			]);
 			done();
 		});
 	});


### PR DESCRIPTION
fix #1135 

As can be seen in the following snippets, deepEqual behavior has changed in node 12 where it became stricter. Update the test cases to accurately reflect the current behavior. We can discuss whether alasql should return array of arrays in these situations separately. 

https://runkit.com/forestfang-stripe/deep-equal-array/1.0.0
https://runkit.com/forestfang-stripe/deep-equal-array/2.0.0