### PR TITLE
Adjust node versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ language: node_js
 node_js: # node plus all mentioned here: https://nodejs.org/en/about/releases/
   - "node"
   - "13"
-  - "12" 
-  - "11"
+  - "12"
   - "10"
-  - "8"
 
 
 script: npm run test:only && npm test
@@ -19,5 +17,5 @@ script: npm run test:only && npm test
 after_success:
   - npm run test:cover
   - bash <(curl -s https://codecov.io/bash)
-  
+
 sudo: false


### PR DESCRIPTION
both node 8 and 11 are no longer maintained as of 2020/1/1 and node 8 also fails to build due to the fact that one of the dependencies now requires node >=10. update list of node to test against

https://nodejs.org/en/about/releases/