### PR TITLE
Return empty results in group by when input is empty

### DIFF
--- a/src/38query.js
+++ b/src/38query.js
@@ -143,7 +143,7 @@ function queryfn3(query) {
 	//			console.log(query.havingfns);
 	if (query.groupfn) {
 		query.data = [];
-		if (0 === query.groups.length) {
+		if (query.groups.length === 0 && query.allgroups.length === 0) {
 			var g = {};
 			if (query.selectGroup.length > 0) {
 				//				console.log(query.selectGroup);
@@ -377,7 +377,7 @@ function queryfn3(query) {
 	// if(query.explain) {
 	// 	if(query.cb) query.cb(query.explaination,query.A, query.B);
 	// 	return query.explaination;
-	// } else 
+	// } else
 */
 
 	//console.log(190,query.intofns);

--- a/test/test813.js
+++ b/test/test813.js
@@ -1,0 +1,34 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+describe('Test 927 group by empty results bug', function () {
+	it('1. Does not return any results if input is empty when using GROUP BY', function (done) {
+		var data = [
+			{a: 1, b: 2, c: undefined},
+			{a: 2, b: 3, c: undefined},
+			{a: undefined, b: 3, c: undefined},
+		];
+
+		var res = alasql('SELECT COUNT(*) FROM ? WHERE a = b', [data]);
+		assert.deepEqual(res, [{'COUNT(*)': 0}]);
+
+		var res = alasql('SELECT a, COUNT(*) FROM ? GROUP BY a', [data]);
+		assert.deepEqual(res, [
+			{a: 1, 'COUNT(*)': 1},
+			{a: 2, 'COUNT(*)': 1},
+			{a: undefined, 'COUNT(*)': 1},
+		]);
+
+		var res = alasql('SELECT c, COUNT(*) FROM ? WHERE a IS NULL GROUP BY c', [data]);
+		assert.deepEqual(res, [{c: undefined, 'COUNT(*)': 1}]);
+
+		var res = alasql('SELECT a, COUNT(*) FROM ? WHERE a = b GROUP BY a', [data]);
+		assert.deepEqual(res, []);
+
+		done();
+	});
+});


### PR DESCRIPTION
fixes #927 

We currently have a fallback check on empty `query.groups` so that we can populate aggregate function default value in a non-groupby SELECT. i.e. `SELECT COUNT(1) as c FROM ? WHERE 1 = 2` should return `[{c:0}]`.

However, `query.groups` can also be empty if there is no input data to group by. In this case, we would expect AlaSQL (and other SQL engines indeed) to not return anything instead of emitting an undefined group. Add an additional check to verify that `allgroups` are empty, that is, there were no GROUP BY clause.
