### PR TITLE
FIX #1433: IFNULL checks only undefined and null

### DIFF
--- a/src/55functions.js
+++ b/src/55functions.js
@@ -167,7 +167,7 @@ stdlib.IIF = function (a, b, c) {
 	}
 };
 stdlib.IFNULL = function (a, b) {
-	return '(' + a + '||' + b + ')';
+	return '(' + a + '==undefined?' + b + ':' + a + ')';
 };
 stdlib.INSTR = function (s, p) {
 	return '((' + s + ').indexOf(' + p + ')+1)';

--- a/test/test815.js
+++ b/test/test815.js
@@ -1,0 +1,60 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('../dist/alasql');
+}
+
+describe('Test 815 IFNULL bug', function () {
+	it('1. Does return 0', function (done) {
+		var data = [
+			{
+				a: 0
+			},
+		];
+		var res = alasql(
+			'SELECT IFNULL(a, 100) as result FROM ?',
+			[data]
+		);
+		assert.deepEqual(res, [
+			{
+				result: 0,
+			},
+		]);
+		done();
+	});
+
+	it('1. Does return false', function (done) {
+		var data = [
+			{
+				a: false
+			},
+		];
+		var res = alasql(
+			'SELECT IFNULL(a, true) as result FROM ?',
+			[data]
+		);
+		assert.deepEqual(res, [
+			{
+				result: false,
+			},
+		]);
+		done();
+	});
+
+	it('1. Does return 100', function (done) {
+		var data = [
+			{
+				a: null
+			},
+		];
+		var res = alasql(
+			'SELECT IFNULL(a, 100) as result FROM ?',
+			[data]
+		);
+		assert.deepEqual(res, [
+			{
+				result: 100,
+			},
+		]);
+		done();
+	});
+});


### PR DESCRIPTION
Fixes IFNULL bug reported in #1433

Now IFNULL checks if the value is null or undefined. Other falsy values should pass the check


