### PR TITLE
Fixes #1776. Allows Case Insensitive distinct keyword with aggregations.

### DIFF
--- a/src/alasqlparser.jison
+++ b/src/alasqlparser.jison
@@ -3016,7 +3016,7 @@ InsertDeleteUpdate
 
 DropTrigger
 	: DROP TRIGGER Literal
-		{ $$ = new yy.DropTrigger({trigger:$3}); }
+		{ $$ = new yy.DropTrigger({trigger:$3});}
 	;
 
 Reindex

--- a/src/alasqlparser.jison
+++ b/src/alasqlparser.jison
@@ -1376,7 +1376,7 @@ FuncValue
 					$$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			} else if(alasql.aggr[$1]) {
 		    	$$ = new yy.AggrValue({aggregatorid: 'REDUCE',
-                      funcid: funcid, expression: exprlist.pop(),distinct:(($3+'').toUpperCase()=='DISTINCT') });
+                      funcid: funcid, expression: exprlist.pop(),distinct:($3?.toUpperCase()=='DISTINCT') });
 		    } else {
 			    $$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			};

--- a/src/alasqlparser.jison
+++ b/src/alasqlparser.jison
@@ -1376,7 +1376,7 @@ FuncValue
 					$$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			} else if(alasql.aggr[$1]) {
 		    	$$ = new yy.AggrValue({aggregatorid: 'REDUCE',
-                      funcid: funcid, expression: exprlist.pop(),distinct:($3=='DISTINCT') });
+                      funcid: funcid, expression: exprlist.pop(),distinct:(($3+'').toUpperCase()=='DISTINCT') });
 		    } else {
 			    $$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			};

--- a/src/alasqlparser.js
+++ b/src/alasqlparser.js
@@ -809,7 +809,7 @@ case 349:
 					this.$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			} else if(alasql.aggr[$$[$0-4]]) {
 		    	this.$ = new yy.AggrValue({aggregatorid: 'REDUCE',
-                      funcid: funcid, expression: exprlist.pop(),distinct:($$[$0-2]=='DISTINCT') });
+                      funcid: funcid, expression: exprlist.pop(),distinct:($$[$0-2]?.toUpperCase()=='DISTINCT') });
 		    } else {
 			    this.$ = new yy.FuncValue({funcid: funcid, args: exprlist});
 			};

--- a/test/test1776.js
+++ b/test/test1776.js
@@ -1,0 +1,25 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+var test = '1776'; // insert test file number
+
+describe('Test ' + test + ' - case-insensitive distinct keyword within aggregations', function () {
+	var data;
+	var res;
+
+	it('a) GROUP_CONCAT aggregation', function () {
+		data = [
+			{a: 1, b: 'x'},
+			{a: 2, b: 'y'},
+			{a: 1, b: 'z'},
+			{a: 1, b: 'x'},
+			{a: 2, b: 'y'},
+		];
+		res = alasql('SELECT a, GROUP_CONCAT(Distinct b) AS b FROM ? GROUP BY a', [data]);
+		assert.equal(res[0].b, 'x,z');
+		assert.equal(res[1].b, 'y');
+	});
+
+});


### PR DESCRIPTION
Fixes #1776. Allows Case Insensitive distinct keyword with aggregations.

Opened a new PR for https://github.com/AlaSQL/alasql/pull/1778 as had some issue with that codebase after fork.

@mathiasrw 
**I have not committed the alasqlparser.js** as mentioned in other PR thinking that will get auto generated and committed some where else in the pipeline. I tested running `yarn build-jison`. 

