### PR TITLE
Let LIKE work correctly with line breaks in values to fix #1734

### DIFF
--- a/src/15utility.js
+++ b/src/15utility.js
@@ -1197,7 +1197,7 @@ var like = (utils.like = function (pattern, value, escape) {
 		} else if (c === '[' || c === ']') {
 			s += c;
 		} else if (c === '%') {
-			s += '.*';
+			s += '[\\s\\S]*';
 		} else if (c === '_') {
 			s += '.';
 		} else if ('/.*+?|(){}'.indexOf(c) > -1) {
@@ -1211,7 +1211,7 @@ var like = (utils.like = function (pattern, value, escape) {
 	s += '$';
 	//    if(value == undefined) return false;
 	//console.log(s,value,(value||'').search(RegExp(s))>-1);
-	return ('' + (value || '')).toUpperCase().search(RegExp(s.toUpperCase())) > -1;
+	return ('' + (value || '')).search(RegExp(s, 'i')) > -1;
 });
 
 utils.glob = function (value, pattern) {

--- a/src/15utility.js
+++ b/src/15utility.js
@@ -1211,7 +1211,7 @@ var like = (utils.like = function (pattern, value, escape) {
 	s += '$';
 	//    if(value == undefined) return false;
 	//console.log(s,value,(value||'').search(RegExp(s))>-1);
-	return ('' + (value || '')).search(RegExp(s, 'i')) > -1;
+	return ('' + (value ?? '')).search(RegExp(s, 'i')) > -1;
 });
 
 utils.glob = function (value, pattern) {

--- a/test/test1734.js
+++ b/test/test1734.js
@@ -1,0 +1,23 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+var test = '1666';
+describe('Test'  + test + 'Newline characters in like', function () {
+	it('1. LIKE', function (done) {
+		var data = [
+			{a: 'one', b: 'first'},
+			{a: 'two', b: 'second\n\ritem'},
+			{a: 'THREE', b: 'THIRD'},
+		];
+
+		var res = alasql('SELECT b FROM ? WHERE a LIKE "T%"', [data]);
+
+		//console.log(res);
+		assert.deepEqual(res, [{b: 'second\n\ritem'}, {b: 'THIRD'}]);
+		done();
+	});
+});

--- a/test/test1734.js
+++ b/test/test1734.js
@@ -36,4 +36,18 @@ describe('Test'  + test + 'Newline characters in like', function () {
 		assert.deepEqual(res, [{b: 'second\n\ritem'}, {b: 'THIRD'}, {b: '\n\rFifth'}, {b: 'Six\nth'}]);
 		done();
 	});
+
+	it('3. LIKE', function (done) {
+		var data = [
+			{a: 'one', b: 0},
+			{a: 'three', b: 'three'},
+			{a: 'two', b: '0ne'},
+		];
+
+		var res = alasql('SELECT b FROM ? WHERE b LIKE "0%"', [data]);
+
+		//console.log(res);
+		assert.deepEqual(res, [{b: 0}, {b: '0ne'}]);
+		done();
+	});
 });

--- a/test/test1734.js
+++ b/test/test1734.js
@@ -11,13 +11,29 @@ describe('Test'  + test + 'Newline characters in like', function () {
 		var data = [
 			{a: 'one', b: 'first'},
 			{a: 'two', b: 'second\n\ritem'},
-			{a: 'THREE', b: 'THIRD'},
+			{a: 'THREE', b: 'THI\n\rRD'},
 		];
 
-		var res = alasql('SELECT b FROM ? WHERE a LIKE "T%"', [data]);
+		var res = alasql('SELECT b FROM ? WHERE b LIKE "t%"', [data]);
 
 		//console.log(res);
-		assert.deepEqual(res, [{b: 'second\n\ritem'}, {b: 'THIRD'}]);
+		assert.deepEqual(res, [{b: 'THI\n\rRD'}]);
+		done();
+	});
+
+	it('2. LIKE', function (done) {
+		var data = [
+			{a: 'one', b: 'Nine'},
+			{a: 'two', b: 'second\n\ritem'},
+			{a: 'THREE', b: 'THIRD'},
+			{a: 'FOUR', b: '\n\rFifth'},
+			{a: 'FIVE', b: 'Six\nth'},
+		];
+
+		var res = alasql('SELECT b FROM ? WHERE b LIKE "%T%"', [data]);
+
+		//console.log(res);
+		assert.deepEqual(res, [{b: 'second\n\ritem'}, {b: 'THIRD'}, {b: '\n\rFifth'}, {b: 'Six\nth'}]);
 		done();
 	});
 });

--- a/test/test244.js
+++ b/test/test244.js
@@ -16,7 +16,7 @@ describe('Test 244 Case-insensitive LIKE', function () {
 		var res = alasql('SELECT b FROM ? WHERE a LIKE "T%"', [data]);
 
 		//console.log(res);
-		assert(res, [{b: 'second'}, {b: 'THIRD'}]);
+		assert.deepEqual(res, [{b: 'second'}, {b: 'THIRD'}]);
 		done();
 	});
 
@@ -33,7 +33,7 @@ describe('Test 244 Case-insensitive LIKE', function () {
 
 		var res = alasql('SELECT * FROM ? WHERE a LIKE "m%"', [data]);
 		//console.log(res);
-		assert(res, [{a: 'MOSCOW'}, {a: 'MINSK'}]);
+		assert.deepEqual(res, [{a: 'MOSCOW'}, {a: 'MINSK'}]);
 		done();
 	});
 });


### PR DESCRIPTION
 Fix #1734 - LIKE will not work correctly when there is a line break.


