### PR TITLE
Fix Issue #1797

### DIFF
--- a/src/38query.js
+++ b/src/38query.js
@@ -200,6 +200,12 @@ function queryfn3(query) {
 			if (!query.havingfn || query.havingfn(g, query.params, alasql)) {
 				//				console.log(g);
 				var d = query.selectgfn(g, query.params, alasql);
+
+				for (const key in query.groupColumns) {
+					if (query.groupColumns[key] !== key
+						&& d[query.groupColumns[key]])
+						delete d[query.groupColumns[key]]
+				}
 				query.data.push(d);
 			}
 		}
@@ -477,7 +483,7 @@ var preIndex = function (query) {
 				// Check if index already exists
 				var ixx =
 					alasql.databases[source.databaseid].tables[source.tableid].indices[
-						hash(source.onrightfns + '`' + source.srcwherefns)
+					hash(source.onrightfns + '`' + source.srcwherefns)
 					];
 				if (!alasql.databases[source.databaseid].tables[source.tableid].dirty && ixx) {
 					source.ix = ixx;
@@ -533,7 +539,7 @@ var preIndex = function (query) {
 				// Check if index exists
 				ixx =
 					alasql.databases[source.databaseid].tables[source.tableid].indices[
-						hash(source.wxleftfns + '`')
+					hash(source.wxleftfns + '`')
 					];
 			}
 			if (!alasql.databases[source.databaseid].tables[source.tableid].dirty && ixx) {

--- a/test/test1797.js
+++ b/test/test1797.js
@@ -1,0 +1,34 @@
+if (typeof exports === 'object') {
+    var assert = require('assert');
+    var alasql = require('..');
+}
+
+var test = '1797';
+
+describe('Test ' + test + ' - select * with alias colname', function () {
+    it('Join with simple subquery', function () {
+        var expected = [{ a: 1, b: 1, c: 1, d: 3 }, { a: 2, b: 1, c: 1, d: 1 }];
+        var data = [
+            { a: 1, b: 1, c: 1 },
+            { a: 1, b: 2, c: 1 },
+            { a: 1, b: 3, c: 1 },
+            { a: 2, b: 1, c: 1 }];
+        var res = alasql(
+            `SELECT *, COUNT(a) as d FROM ? GROUP BY a`,
+            [data]
+        );
+        assert.deepEqual(res, expected);
+    });
+
+    it('Join with simple subquery', function () {
+        var expected = [{ a: 1, b: 1, c: 1, d: 5 }, { a: 2, b: 1, c: 1, d: 2 }];
+        var data = [{ a: 1, b: 1, c: 1 }, { a: 1, b: 1, c: 2 }, { a: 1, b: 1, c: 3 }, { a: 1, b: 2, c: 1 }, { a: 1, b: 3, c: 1 }, { a: 2, b: 1, c: 1 }, { a: 2, b: 1, c: 2 }];
+        var res = alasql(
+            `SELECT *, COUNT(a) as d FROM ? GROUP BY a`,
+            [data]
+        );
+        assert.deepEqual(res, expected);
+    });
+
+
+});


### PR DESCRIPTION
**Proposed Change**

Fixed issue #1797 where adding alias alongside select(*) was producing duplicate columns. Added the testcase to the file test1797.js that passed without any issues.

**Testing**
 data and query 
![image](https://github.com/AlaSQL/alasql/assets/31096082/7c94f83d-cb28-480d-8b54-ee939644b47f)
Before: output: This has duplicate `COUNT(a)` along with `d`
![image](https://github.com/AlaSQL/alasql/assets/31096082/d46e4475-5d14-440e-b4ae-0e09d3c67cd9)

After: output, clearly duplicate col has been removed.
![image](https://github.com/AlaSQL/alasql/assets/31096082/0455588a-dc25-4f9f-a3dc-92a20b4e49e5)



After: data and query

