### PR TITLE
Fix for SELECT query (a AS b, b AS c), change in behavior between 4.1.9 and 4.1.10

### DIFF
--- a/src/38query.js
+++ b/src/38query.js
@@ -202,8 +202,10 @@ function queryfn3(query) {
 				var d = query.selectgfn(g, query.params, alasql);
 
 				for (const key in query.groupColumns) {
-					if (query.groupColumns[key] !== key && d[query.groupColumns[key]])
+					// ony remove columns where the alias is also not a column in the result
+					if (query.groupColumns[key] !== key && d[query.groupColumns[key]] && !query.groupColumns[query.groupColumns[key]]){
 						delete d[query.groupColumns[key]];
+					}
 				}
 				query.data.push(d);
 			}

--- a/test/test1820.js
+++ b/test/test1820.js
@@ -1,0 +1,26 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+describe('Test 1820 - SELECT query (a AS b, b AS c)', function () {
+
+	it('1. Where IN with refs', function (done) {
+		let item1 = { a: 1, b: "hello" };
+		let item2 = { a: 2, b: "" };
+
+		var res = alasql('SELECT a as b, b as c FROM ? GROUP BY a,b', [[item1, item2]]);
+
+		assert.deepEqual(res, [{
+			b: 1,
+			c: "hello"
+		}, {
+			b: 2,
+			c: ""
+		}]);
+
+		done();
+	});
+});

--- a/test/test1820.js
+++ b/test/test1820.js
@@ -7,7 +7,7 @@ if (typeof exports === 'object') {
 
 describe('Test 1820 - SELECT query (a AS b, b AS c)', function () {
 
-	it('1. Where IN with refs', function (done) {
+	it('1. Select query where alias of one column is also a column name in the result set', function (done) {
 		let item1 = { a: 1, b: "hello" };
 		let item2 = { a: 2, b: "" };
 


### PR DESCRIPTION
Fixes https://github.com/AlaSQL/alasql/issues/1820

- Only remove columns where the alias is not a column in the result itself
- Add unit test


Thank you for the time you are putting into AlaSQL!


