### PR TITLE
Add Database interface to type definitions

### DIFF
--- a/types/alasql.d.ts
+++ b/types/alasql.d.ts
@@ -138,6 +138,22 @@ declare module 'alasql' {
 		[tableName: string]: table;
 	}
 
+	interface Database {
+		databaseid: string;
+		dbversion: number;
+		tables: {[key: string]: any};
+		views: {[key: string]: any};
+		triggers: {[key: string]: any};
+		indices: {[key: string]: any};
+		objects: {[key: string]: any};
+		counter: number;
+		sqlCache: {[key: string]: any};
+		sqlCacheSize: number;
+		astCache: {[key: string]: any};
+		resetSqlCache: () => void;
+		exec: (sql: string, params?: object, cb?: Function) => any;
+		autoval: (tablename: string, colname: string, getNext: boolean) => any;
+	}
 	interface AlaSQL {
 		options: AlaSQLOptions;
 		error: Error;
@@ -150,6 +166,7 @@ declare module 'alasql' {
 		autoval(tablename: string, colname: string, getNext?: boolean): number;
 		yy: {};
 		setXLSX(xlsxlib: typeof xlsx): void;
+		Database: Database;
 
 		/**
 		 * Array of databases in the AlaSQL object.


### PR DESCRIPTION
This fixes issue #1180 and adds the property Database to the [types/alasql.d.ts](https://github.com/AlaSQL/alasql/blob/674b9271c1d3c0498e6ce0f6b1f53baa44671c25/types/alasql.d.ts) file.

The [Getting Started](https://github.com/alasql/alasql/wiki/Getting%20started) section has this code:

```JavaScript
    var mybase = new alasql.Database();
    mybase.exec('CREATE TABLE one (two INT)');
```

However, when using TypeScript, this causes a type error such as:
```bash
src/lib/utils.ts:239:25 - error TS2551: Property 'Database' does not exist on type 'AlaSQL'. Did you mean 'databases'?

239   const db = new alasql.Database();
                            ~~~~~~~~
```

The cause is that [types/alasql.d.ts] has no `Database` in its type definitions.  This PR adds that type definition.



