### PR TITLE
Fixes error message for missing tables using JOIN

### DIFF
--- a/src/44defcols.js
+++ b/src/44defcols.js
@@ -55,11 +55,21 @@ yy.Select.prototype.compileDefCols = function (query, databaseid) {
 
 			//			console.log(jn);
 			if (jn.table) {
-				var alias = jn.table.tableid;
-				if (jn.as) alias = jn.as;
 				var alias = jn.as || jn.table.tableid;
-				var table = alasql.databases[jn.table.databaseid || databaseid].tables[jn.table.tableid];
+				var databaseId = jn.table.databaseid || databaseid;
+				var database = alasql.databases[databaseId];
+
+				if (database === undefined) {
+					throw new Error('Database does not exist: ' + databaseId);
+				}
+
+				var table = database.tables[jn.table.tableid];
 				//				console.log(jn.table.tableid, jn.table.databaseid);
+
+				if (table === undefined) {
+					throw new Error('Table does not exist: ' + jn.table.tableid);
+				}
+
 				if (table.columns) {
 					table.columns.forEach(function (col) {
 						if (defcols[col.columnid]) {

--- a/test/test1885.js
+++ b/test/test1885.js
@@ -1,0 +1,36 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+describe('Test 1885 - consistent error messages for missing tables', function () {
+	const test = '1885'; // insert test file number
+
+	before(function () {
+		alasql('create database test' + test);
+		alasql('use test' + test);
+		alasql('CREATE TABLE validTable (a INT, b INT, PRIMARY KEY (a,b))');
+	});
+
+	after(function () {
+		alasql('drop database test' + test);
+	});
+
+	it('SELECT returns standard error message', function () {
+		assert.throws(() => alasql('select * from invalidTable'), {
+			message: 'Table does not exist: invalidTable'
+		});
+	});
+
+	it('JOIN ON returns standard error message', function () {		
+		assert.throws(() => alasql('select * from validTable JOIN invalidTable ON validTable.a = invalidTable.b'), {
+			message: 'Table does not exist: invalidTable'
+		});
+	});
+
+	it('JOIN USING returns standard error message', function () {		
+		assert.throws(() => alasql('select * from validTable JOIN invalidTable USING a'), {
+			message: 'Table does not exist: invalidTable'
+		});
+	});
+});


### PR DESCRIPTION
Fixes issue #1885, includes test for `SELECT` and `JOIN` error messages.


Thank you for the time you are putting into AlaSQL!


