### PR TITLE
fix: update typeof comparision to be string based

### DIFF
--- a/src/91indexeddb.js
+++ b/src/91indexeddb.js
@@ -340,7 +340,7 @@ IDB.fromTable = function (databaseid, tableid, cb, idx, query) {
 			const cursor = cur.result;
 			if (cursor) {
 				// if keyPath(columns) is not present then we take the key and value as object.
-				const cursorValue = typeof cursor === Object ? cursor.value : {[cursor.key]: cursor.value};
+				const cursorValue = typeof cursor === "object" ? cursor.value : {[cursor.key]: cursor.value};
 				res.push(cursorValue);
 				cursor.continue();
 			} else {


### PR DESCRIPTION
In the IndexedDB store comparision for the cursor in the from api call is against an object and from documentation the typeof returns a string so comparision should be string based.

This initial change is to validate against existing test, further review of tests is needed to ensure this does not regress later.

This is to resolve issue #1775 

Thank you for the time you are putting into AlaSQL!

