### PR TITLE
Add jsonl support

### DIFF
--- a/src/15utility.js
+++ b/src/15utility.js
@@ -614,7 +614,7 @@ utils.autoExtFilename = function (filename, ext, config) {
 	config = config || {};
 	if (
 		typeof filename !== 'string' ||
-		filename.match(/^[A-z]+:\/\/|\n|\..{2,4}$/) ||
+		filename.match(/^[A-z]+:\/\/|\n|\..{2,6}$/) ||
 		config.autoExt === 0 ||
 		config.autoExt === false
 	) {

--- a/src/15utility.js
+++ b/src/15utility.js
@@ -614,7 +614,7 @@ utils.autoExtFilename = function (filename, ext, config) {
 	config = config || {};
 	if (
 		typeof filename !== 'string' ||
-		filename.match(/^[A-z]+:\/\/|\n|\..{2,6}$/) ||
+		filename.match(/^[A-Z]+:\/\/|\n|\..{2,6}$/i) ||
 		config.autoExt === 0 ||
 		config.autoExt === false
 	) {

--- a/src/84from.js
+++ b/src/84from.js
@@ -131,28 +131,46 @@ alasql.from.JSON = function (filename, opts, cb, idx, query) {
 		if (cb) {
 			res = cb(res, idx, query);
 		}
-	});
+	}),
+		err => {
+			throw new Error(err);
+		};
 	return res;
 };
 
-alasql.from.JSONL = function (filename, opts, cb, idx, query) {
-	var res;
-	filename = alasql.utils.autoExtFilename(filename, 'jsonl', opts);
-	alasql.utils.loadFile(filename, !!cb, function (data) {
-		res = data.split(/\r?\n/);
-		// Remove last line if empty
-		if (res[res.length - 1] === '') {
-			res.pop();
-		}
-		for (var i = 0, ilen = res.length; i < ilen; i++) {
-			res[i] = JSON.parse(res[i]);
-		}
-		if (cb) {
-			res = cb(res, idx, query);
-		}
-	});
-	return res;
+const jsonl = ext => {
+	return function (filename, opts, cb, idx, query) {
+		let out = [];
+		filename = alasql.utils.autoExtFilename(filename, ext, opts);
+		alasql.utils.loadFile(
+			filename,
+			!!cb,
+			function (data) {
+				data.split(/\r?\n/).forEach((line, ix) => {
+					const trimmed = line.trim();
+					if (trimmed !== '') {
+						// skip empty lines, we do not use filter on an input, as we want to preserve line numbers
+						try {
+							out.push(JSON.parse(trimmed));
+						} catch (e) {
+							throw new Error(`Could not parse JSON at line ${ix}: ${e.toString()}`);
+						}
+					}
+				});
+				if (cb) {
+					res = cb(out, idx, query);
+				}
+			},
+			err => {
+				throw new Error(err);
+			}
+		);
+		return out;
+	};
 };
+
+alasql.from.JSONL = jsonl('jsonl');
+alasql.from.NDJSON = jsonl('ndjson');
 
 alasql.from.TXT = function (filename, opts, cb, idx, query) {
 	var res;

--- a/src/84from.js
+++ b/src/84from.js
@@ -135,6 +135,25 @@ alasql.from.JSON = function (filename, opts, cb, idx, query) {
 	return res;
 };
 
+alasql.from.JSONL = function (filename, opts, cb, idx, query) {
+	var res;
+	filename = alasql.utils.autoExtFilename(filename, 'jsonl', opts);
+	alasql.utils.loadFile(filename, !!cb, function (data) {
+		res = data.split(/\r?\n/);
+		// Remove last line if empty
+		if (res[res.length - 1] === '') {
+			res.pop();
+		}
+		for (var i = 0, ilen = res.length; i < ilen; i++) {
+			res[i] = JSON.parse(res[i]);
+		}
+		if (cb) {
+			res = cb(res, idx, query);
+		}
+	});
+	return res;
+};
+
 alasql.from.TXT = function (filename, opts, cb, idx, query) {
 	var res;
 	filename = alasql.utils.autoExtFilename(filename, 'txt', opts);

--- a/test/test1919.js
+++ b/test/test1919.js
@@ -1,0 +1,51 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+/*
+	Test for issue #1919
+*/
+describe(`Test 1919 Load data from JSONL file`, function () {
+	const expectedResult = [
+		{
+			a: 'foo',
+			b: 5,
+			c: true,
+			d: null
+		},
+		{
+			a: 'bar',
+			b: 8,
+			c: false,
+			d: null
+		}
+	];
+	it('1. Load JSONL', function (done) {
+		alasql('SELECT * FROM JSONL("' + __dirname + '/test1919")', [], function (res) {
+			assert.deepEqual(res, expectedResult);
+			done();
+		});
+	});
+
+	it('2. Load NDJSON', function (done) {
+		alasql('SELECT * FROM NDJSON("' + __dirname + '/test1919")', [], function (res) {
+			assert.deepEqual(res, expectedResult);
+			done();
+		});
+	});
+
+	it('3. Load NDJSON - will accept file with different  extension', function (done) {
+		alasql('SELECT * FROM NDJSON("' + __dirname + '/test1919.jsonl")', [], function (res) {
+			assert.deepEqual(res, expectedResult);
+			done();
+		});
+	});
+
+	it('4. Load JSONL - will accept file with different extension', function (done) {
+		alasql('SELECT * FROM JSONL("' + __dirname + '/test1919.ndjson")', [], function (res) {
+			assert.deepEqual(res, expectedResult);
+			done();
+		});
+	});
+});

--- a/test/test1919.jsonl
+++ b/test/test1919.jsonl
@@ -1,0 +1,2 @@
+{"a":"foo","b":5.0,"c":true,"d":null}
+{"a":"bar","b":8.0,"c":false,"d":null}

--- a/test/test1919.ndjson
+++ b/test/test1919.ndjson
@@ -1,0 +1,2 @@
+{"a":"foo","b":5.0,"c":true,"d":null}
+{"a":"bar","b":8.0,"c":false,"d":null}


### PR DESCRIPTION
JSON support is great, but JSONL is very common in streaming cases (e.g. logs). 

```
$ cat test.jsonl
{"a": 1}
{"a": 2}
{"a": 42}

$ alasql "select * from jsonl('./test') where a > 1"
[
  {
    "a": 2
  },
  {
    "a": 42
  }
]
```