### PR TITLE
Fix EXISTS Function for Subqueries (Issue #1904)

### DIFF
--- a/src/41exists.js
+++ b/src/41exists.js
@@ -1,8 +1,9 @@
 /*
 //
-// EXISTS and other subqueries functions  functions for Alasql.js
+// EXISTS and other subqueries functions for AlaSQL.js
 // Date: 03.11.2014
 // (c) 2014, Andrey Gershun
+// Modified by: Midwayne
 //
 */
 
@@ -20,12 +21,13 @@ yy.ExistsValue = class ExistsValue {
 	}
 
 	toJS(context, tableid, defcols) {
-		return `this.existsfn[${this.existsidx}](params, null, ${context}).data.length`;
+		// Updated to return a boolean value correctly
+		return `!!this.existsfn[${this.existsidx}](params, null, ${context}).data.length`;
 	}
 };
 
 //
-// Prepare subqueries and exists
+// Prepare subqueries and EXISTS
 //
 alasql.precompile = function (statement, databaseid, params) {
 	if (!statement) return;


### PR DESCRIPTION
Changes Made:
- Updated yy.ExistsValue class in 41exists.js to correctly handle EXISTS function in subqueries.
- Adjusted toJS method to return a boolean value based on the presence of data in the subquery result.

Testing:
- All tests passed successfully when executed with yarn test.

Related Issue:
This pull request addresses [issue #1904](https://github.com/AlaSQL/alasql/issues/1904).