### PR TITLE
fix insertion of empty objects with union all statements

### DIFF
--- a/src/38query.js
+++ b/src/38query.js
@@ -167,8 +167,16 @@ function queryfn3(query) {
 			ilen = nd.data.length;
 			for (var i = 0; i < ilen; i++) {
 				var r = {};
-				for (var j = Math.min(query.columns.length, nd.columns.length) - 1; 0 <= j; j--) {
-					r[query.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
+				if (query.columns.length) {
+					jlen = Math.min(query.columns.length, nd.columns.length);
+					for (var j = 0; j < jlen; j++) {
+						r[query.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
+					}
+				} else {
+					jlen = nd.columns.length;
+					for (var j = 0; j < jlen; j++) {
+						r[nd.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
+					}
 				}
 				ud.push(r);
 			}

--- a/test/test1684.js
+++ b/test/test1684.js
@@ -1,0 +1,31 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+describe('Test 1684 - UNION ALL still not returning correct results bug', function () {
+	it('1. should not insert empty objects in results when using UNION ALL Expression', function (done) {
+		var data = 	[
+      { "city": "Madrid", "population": 3041579 },
+      { "city": "Rome", "population": 2863223 },
+      { "city": "Paris", "population": 2249975 }
+    ] 
+		var sql =   "SELECT city FROM :data WHERE city = 'Madrid' \
+                UNION ALL SELECT city FROM :data WHERE city = 'Rome' \
+                UNION ALL SELECT city FROM :data WHERE city = 'Paris' \
+                "
+    var res = alasql(sql, { data });
+    assert.deepEqual(res, [{ city: 'Madrid' }, { city: 'Rome' }, { city: 'Paris' }]);
+
+		var sql =   "SELECT * FROM :data WHERE city = 'Madrid' \
+                UNION ALL SELECT * FROM :data WHERE city = 'Rome' \
+                UNION ALL SELECT * FROM :data WHERE city = 'Paris' \
+                "
+    var res = alasql(sql, { data });
+    assert.deepEqual(res, [{ city: 'Madrid', population: 3041579 }, { city: 'Rome', population: 2863223 }, { city: 'Paris', population: 2249975 }]);
+
+		done();
+	});
+});


### PR DESCRIPTION
This is an attempt to fix the issue #1684 

Considering approach from #1415 , implemented similar empty query conditional check for UNION ALL 

will be actively looking out for better approach for the problem.
