### PR TITLE
Fix Bad Callback For Error

### DIFF
--- a/src/40select.js
+++ b/src/40select.js
@@ -344,7 +344,10 @@ yy.Select = class Select {
 			// the (data, err) standard is maintained here.
 			var res1 = queryfn(query, oldscope, function (res, err) {
 				if (err) {
-					return cb(null, err);
+					if (cb) {
+						return cb(null, err);
+					}
+					throw err;
 				}
 				if (query.rownums.length > 0) {
 					for (var i = 0, ilen = res.length; i < ilen; i++) {


### PR DESCRIPTION
### Description
This callback isn't always passed, since these functions all support promises. If the callback is not defined, the error should just be re-thrown.