### PR TITLE
Fix code scanning alert no. 85: Bad HTML filtering regexp

### DIFF
--- a/modules/xlsx/xlsx.js
+++ b/modules/xlsx/xlsx.js
@@ -21542,7 +21542,7 @@ function html_to_sheet(str, _opts) {
 	var opts = _opts || {};
 	var dense = (opts.dense != null) ? opts.dense : DENSE;
 	var ws = ({}); if(dense) ws["!data"] = [];
-	str = str.replace(/<!--.*?-->/g, "");
+	str = str.replace(/<!--[\s\S]*?-->/g, "");
 	var mtch = str.match(/<table/i);
 	if(!mtch) throw new Error("Invalid HTML: could not find <table>");
 	var mtch2 = str.match(/<\/table/i);

--- a/modules/xlsx/xlsx.js
+++ b/modules/xlsx/xlsx.js
@@ -21542,7 +21542,7 @@ function html_to_sheet(str, _opts) {
 	var opts = _opts || {};
 	var dense = (opts.dense != null) ? opts.dense : DENSE;
 	var ws = ({}); if(dense) ws["!data"] = [];
-	str = str.replace(/<!--[\s\S]*?-->/g, "");
+	str = str.replace(/<!--[\s\S]*?(-->|$)/g, "");
 	var mtch = str.match(/<table/i);
 	if(!mtch) throw new Error("Invalid HTML: could not find <table>");
 	var mtch2 = str.match(/<\/table/i);


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/85](https://github.com/AlaSQL/alasql/security/code-scanning/85)

The best way to fix the problem is to use a well-tested HTML sanitization library instead of relying on custom regular expressions. However, if we need to stick with regular expressions for some reason, we should update the regular expression to handle multiline comments correctly.

To fix the issue without changing existing functionality, we will update the regular expression on line 21545 to match comments containing newlines. We will replace `<!--.*?-->` with `<!--[\s\S]*?-->`, which will correctly match comments that span multiple lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
