### PR TITLE
Fix code scanning alert no. 87: Bad HTML filtering regexp

### DIFF
--- a/modules/xlsx/xlsx.mjs
+++ b/modules/xlsx/xlsx.mjs
@@ -21647,7 +21647,7 @@ function html_to_sheet(str/*:string*/, _opts)/*:Workbook*/ {
 	var opts = _opts || {};
 	var dense = (opts.dense != null) ? opts.dense : DENSE;
 	var ws/*:Worksheet*/ = ({}/*:any*/); if(dense) ws["!data"] = [];
-	str = str.replace(/<!--.*?-->/g, "");
+	str = str.replace(/<!--[\s\S]*?-->/g, "");
 	var mtch/*:any*/ = str.match(/<table/i);
 	if(!mtch) throw new Error("Invalid HTML: could not find <table>");
 	var mtch2/*:any*/ = str.match(/<\/table/i);


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/87](https://github.com/AlaSQL/alasql/security/code-scanning/87)

To fix the problem, we should use a more robust regular expression that can handle multiline HTML comments. The best way to achieve this is to use a regular expression that matches any character, including newlines, between the comment delimiters `<!--` and `-->`.

We will replace the current regular expression `<!--.*?-->` with `<!--[\s\S]*?-->`. The `[\s\S]` pattern matches any character, including newlines, ensuring that multiline comments are correctly matched and removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
