### PR TITLE
Fix code scanning alert no. 86: Bad HTML filtering regexp

### DIFF
--- a/modules/xlsx/dist/xlsx.extendscript.js
+++ b/modules/xlsx/dist/xlsx.extendscript.js
@@ -21698,7 +21698,7 @@ function html_to_sheet(str, _opts) {
 	var opts = _opts || {};
 	var dense = (opts.dense != null) ? opts.dense : DENSE;
 	var ws = ({}); if(dense) ws["!data"] = [];
-	str = str.replace(/<!--.*?-->/g, "");
+	str = str.replace(/<!--[\s\S]*?-->/g, "");
 	var mtch = str.match(/<table/i);
 	if(!mtch) throw new Error("Invalid HTML: could not find <table>");
 	var mtch2 = str.match(/<\/table/i);


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/86](https://github.com/AlaSQL/alasql/security/code-scanning/86)

To fix the problem, we should replace the current regular expression with one that correctly matches HTML comments containing newlines. The best way to achieve this is to use a regex that includes the `[\s\S]` pattern, which matches any character including newlines. This ensures that multiline comments are properly matched and removed.

We will update the regex on line 21701 in the file `modules/xlsx/dist/xlsx.extendscript.js` to handle multiline comments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
