### PR TITLE
Fix code scanning alert no. 90: Replacement of a substring with itself

### DIFF
--- a/src/15utility.js
+++ b/src/15utility.js
@@ -124,15 +124,14 @@ var doubleq = (utils.doubleq = function (s) {
 });
 
 /**
-  Replace sigle quote to escaped single quote
+  Replace single quote with escaped single quote
   @param {string} s Source string
   @return {string} Replaced string
 
-  @todo Chack this functions
-
-  */
+  @todo Check this function
+*/
 var doubleqq = (utils.doubleqq = function (s) {
-	return s.replace(/\'/g, "\\'");
+	return s.replace(/'/g, "\\'");
 });
 
 /**

--- a/src/15utility.js
+++ b/src/15utility.js
@@ -132,7 +132,7 @@ var doubleq = (utils.doubleq = function (s) {
 
   */
 var doubleqq = (utils.doubleqq = function (s) {
-	return s.replace(/\'/g, "'");
+	return s.replace(/\'/g, "\\'");
 });
 
 /**


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/90](https://github.com/AlaSQL/alasql/security/code-scanning/90)

To fix the problem, we need to modify the replacement string in the `doubleqq` function to correctly escape single quotes. Instead of replacing single quotes with single quotes, we should replace them with escaped single quotes (`\'`). This will ensure that single quotes in the input string are properly escaped.

- Modify the `doubleqq` function to replace single quotes with escaped single quotes.
- Update the replacement string in the `replace` method from `'` to `\\'`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
