### PR TITLE
Fix code scanning alert no. 34: Incomplete string escaping or encoding

### DIFF
--- a/test/test374.js
+++ b/test/test374.js
@@ -134,7 +134,7 @@ SELECT FLOOR(@val)     -- 0
 		tests = (/\/\*([\S\s]+)\*\//m.exec(tests) || ['', ''])[1];
 
 		tests
-			.replace('\r', '')
+			.replace(/\r/g, '')
 			.trim()
 			.split('\n')
 			.forEach(function (test) {


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/34](https://github.com/AlaSQL/alasql/security/code-scanning/34)

To fix the problem, we need to ensure that all occurrences of `'\r'` are replaced in the `tests` string. This can be achieved by using a regular expression with the global flag (`g`). This way, every instance of `'\r'` in the string will be replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
