### PR TITLE
Fix code scanning alert no. 35: Incomplete string escaping or encoding

### DIFF
--- a/test/test374.js
+++ b/test/test374.js
@@ -134,7 +134,7 @@ SELECT FLOOR(@val)     -- 0
 		tests = (/\/\*([\S\s]+)\*\//m.exec(tests) || ['', ''])[1];
 
 		tests
-			.replace('\r', '')
+			.replace(/\r/g, '')
 			.trim()
 			.split('\n')
 			.forEach(function (test) {

--- a/test/test376.js
+++ b/test/test376.js
@@ -239,7 +239,7 @@ SELECT ASCII('ÿ'); -- 255 - Latin small letter y with diaeresis
 		tests = (/\/\*([\S\s]+)\*\//m.exec(tests) || ['', ''])[1];
 
 		tests
-			.replace('\r', '')
+			.replace(/\r/g, '')
 			.trim()
 			.split('\n')
 			.forEach(function (test) {


### PR DESCRIPTION
Fixes [https://github.com/AlaSQL/alasql/security/code-scanning/35](https://github.com/AlaSQL/alasql/security/code-scanning/35)

To fix the problem, we need to ensure that all occurrences of `\r` in the `tests` string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of `\r` is replaced, not just the first one.

The specific change involves modifying the `replace` method call on line 242 to use a regular expression with the global flag.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
