### PR TITLE
Remove `data` from the stored `sqlCache` statement closure

### DIFF
--- a/test/test2027.js
+++ b/test/test2027.js
@@ -22,6 +22,12 @@ describe('Test 2007 - SQL cache', function () {
 		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
 		assert.equal(res.length, 3);
 
+		// Delete all rows
+		alasql('DELETE FROM osoby');
+
+		// Assert that the cache is still empty for "data"
+		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
+
 		// Insert more rows
 		alasql('INSERT INTO osoby VALUES (4, "Jack"), (5, "Paul")');
 
@@ -30,6 +36,6 @@ describe('Test 2007 - SQL cache', function () {
 
 		// Cache should still be empty for "data"
 		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
-		assert.equal(res2.length, 5);
+		assert.equal(res2.length, 2);
 	});
 });

--- a/test/test2027.js
+++ b/test/test2027.js
@@ -17,14 +17,19 @@ describe('Test 2007 - SQL cache', function () {
 	it('A) Execute query and assert cache for `data` afterwards', () => {
 		alasql('CREATE TABLE osoby (id INT, meno STRING)');
 		alasql('INSERT INTO osoby VALUES (1, "John"), (2, "Jane"), (3, "Jake")');
-		alasql('SELECT * FROM osoby');
+		var res = alasql('SELECT * FROM osoby');
 
 		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
+		assert.equal(res.length, 3);
+
+		// Insert more rows
+		alasql('INSERT INTO osoby VALUES (4, "Jack"), (5, "Paul")');
 
 		// Execute same query from cache again, the cache is hit now
-		alasql('SELECT * FROM osoby');
+		var res2 = alasql('SELECT * FROM osoby');
 
 		// Cache should still be empty for "data"
 		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
+		assert.equal(res2.length, 5);
 	});
 });

--- a/test/test2027.js
+++ b/test/test2027.js
@@ -1,0 +1,30 @@
+const alasql = require('../dist/alasql.js');
+
+if (typeof exports === 'object') {
+	var assert = require('assert');
+}
+
+describe('Test 2007 - SQL cache', function () {
+	before(function () {
+		alasql('create database test');
+		alasql('use test');
+	});
+
+	after(function () {
+		alasql('drop database test');
+	});
+
+	it('A) Execute query and assert cache for `data` afterwards', () => {
+		alasql('CREATE TABLE osoby (id INT, meno STRING)');
+		alasql('INSERT INTO osoby VALUES (1, "John"), (2, "Jane"), (3, "Jake")');
+		alasql('SELECT * FROM osoby');
+
+		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
+
+		// Execute same query from cache again, the cache is hit now
+		alasql('SELECT * FROM osoby');
+
+		// Cache should still be empty for "data"
+		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
+	});
+});

--- a/test/test2027.js
+++ b/test/test2027.js
@@ -26,6 +26,7 @@ describe('Test 2007 - SQL cache', function () {
 		alasql('DELETE FROM osoby');
 
 		// Assert that the cache is still empty for "data"
+		// Without the fix, the cache would still contain the data from the previous query even though all rows were deleted
 		assert.deepEqual(alasql.databases["test"].sqlCache["-169125189"].query.data, []);
 
 		// Insert more rows


### PR DESCRIPTION
Remove the `data` property from the sql cache after executing the query, as it's pointless for re-using from cache.
It just retains table data which could otherwise be garbage collected sooner.
Fixes #2027.

Thank you for the time you are putting into AlaSQL!


