### PR TITLE
Fix JSONL source JOIN & Improve error handling for JSON & JSONL source

### DIFF
--- a/src/84from.js
+++ b/src/84from.js
@@ -133,7 +133,12 @@ alasql.from.JSON = function (filename, opts, cb, idx, query) {
 		}
 	}),
 		err => {
-			throw new Error(err);
+			const error = err instanceof Error ? err : new Error(err);
+			if(query && query.cb) {
+				query.cb(null, error);
+				return;
+			}
+			throw error;
 		};
 	return res;
 };
@@ -158,11 +163,16 @@ const jsonl = ext => {
 					}
 				});
 				if (cb) {
-					res = cb(out, idx, query);
+					out = cb(out, idx, query);
 				}
 			},
 			err => {
-				throw new Error(err);
+				const error = err instanceof Error ? err : new Error(err);
+				if(query && query.cb) {
+					query.cb(null, error);
+					return;
+				}
+				throw error;
 			}
 		);
 		return out;


### PR DESCRIPTION

- Fix: when join JSONL source, "ReferenceError: res is not defined" error will be thrown
- Improve: make the user code possible to capture & handle errors from JSON & JSONL source

