### PR TITLE
Enable trigger callback parameter test

### DIFF
--- a/test/test1119.js
+++ b/test/test1119.js
@@ -3,7 +3,7 @@ if (typeof exports === 'object') {
 	var alasql = require('..'); // You might need to adjust the path depending on where you save the test file
 }
 
-describe.skip('Test 1119 - Trigger callback parameter', function () {
+describe('Test 1119 - Trigger callback parameter', function () {
 	const test = '1119'; // Test file number
 
 	before(function () {


### PR DESCRIPTION
## Summary
- enable skipped trigger callback test

## Testing
- `yarn install` *(fails: tunneling socket could not be established)*
- `yarn test --bail` *(fails: package doesn't seem to be present in lockfile)*