### PR TITLE
Update broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Thanks to all the people who already contributed!
 * [Andrey Gershun](https://github.com/alasql)
 * [Mathias Rangel Wulff](https://twitter.com/rangelwulff)
 
-AlaSQL is an [OPEN Open Source Project](http://openopensource.org/). This means that:
+AlaSQL is an [OPEN Open Source Project](https://openopensource.github.io). This means that:
 
 > Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. This project is more like an open wiki than a standard guarded open source project.
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ Thanks to all the people who already contributed!
 * [Andrey Gershun](https://github.com/alasql)
 * [Mathias Rangel Wulff](https://twitter.com/rangelwulff)
 
-AlaSQL is an [OPEN Open Source Project](https://openopensource.github.io). This means that:
+AlaSQL is an [OPEN Open Source Project](https://openopensource.github.io/). This means that:
 
 > Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. This project is more like an open wiki than a standard guarded open source project.
 


### PR DESCRIPTION
http://openopensource.org currently redirects to a holding page and appears to be dead.

Poking around the [web.archive.org for openopensource.org](https://web.archive.org/web/20191211082044/https://openopensource.org/), the URL seems to have moved to "https://openopensource.github.io".

(Although the [project itself](https://github.com/openopensource/openopensource.github.io) is archived.)