### PR TITLE
Fix: 2149 cli docker / pipe issues

### DIFF
--- a/bin/alasql-cli.js
+++ b/bin/alasql-cli.js
@@ -10,7 +10,6 @@
 let alasql = require('../dist/alasql.fs.js');
 let path = require('path');
 let fs = require('fs');
-let stdin = process.openStdin();
 let yargs = require('yargs')
 	.strict()
 	.usage(
@@ -60,10 +59,6 @@ let yargs = require('yargs')
 let argv = yargs.argv;
 let sql = '';
 let params = [];
-let pipedData = '';
-stdin.on('data', function (chunk) {
-	pipedData += chunk;
-});
 
 if (argv.v) {
 	console.log(alasql.version);
@@ -87,15 +82,8 @@ if (argv.f) {
 	sql = argv._.shift() || '';
 
 	// if data is not piped
-	if (Boolean(process.stdin.isTTY)) {
-		execute(sql, argv._);
-	}
+	execute(sql, argv._);
 }
-
-// if data is piped
-stdin.on('end', function () {
-	execute(pipedData, argv._);
-});
 
 /**
  * Execute SQL query

--- a/bin/alasql-cli.js
+++ b/bin/alasql-cli.js
@@ -57,33 +57,73 @@ let yargs = require('yargs')
 	.epilog('\nMore information about the library: www.alasql.org');
 
 let argv = yargs.argv;
-let sql = '';
-let params = [];
+
+// Regex patterns for detecting functions
+const re = {
+	txt: /txt\s*\(\s*\)/i,
+};
+
+// Helper function to check if SQL contains txt() and stdin is piped
+function isPipeData(sql) {
+	return sql && !process.stdin.isTTY && re.txt.test(sql);
+}
+
+// Helper function to setup stdin handling
+function pipeIsSQL() {
+	const stdin = process.openStdin();
+	let pipedData = '';
+	stdin.on('data', function (chunk) {
+		pipedData += chunk;
+	});
+	stdin.on('end', function () {
+		execute(pipedData, argv._);
+	});
+	return stdin;
+}
+
+// Helper function to load and validate SQL file
+function loadSqlFile(filePath) {
+	if (!fs.existsSync(filePath)) {
+		console.error('Error: file not found');
+		process.exit(1);
+	}
+	if (isDirectory(filePath)) {
+		console.error('Error: file expected but directory found');
+		process.exit(1);
+	}
+	return fs.readFileSync(filePath, 'utf8').toString();
+}
+
+// Main execution logic
+function main() {
+	let sql = '';
+	let pipeIsData = false;
+
+	if (argv.f) {
+		sql = loadSqlFile(argv.f);
+		pipeIsData = isPipeData(sql);
+	} else {
+		sql = argv._.shift() || '';
+		pipeIsData = isPipeData(sql);
+	}
+
+	// Setup stdin handling only if not using txt() pipe
+	if (!pipeIsData) {
+		pipeIsSQL();
+	}
+
+	// Execute immediately if we have SQL or are using txt() pipe
+	if (sql || pipeIsData) {
+		execute(sql, argv._);
+	}
+}
 
 if (argv.v) {
 	console.log(alasql.version);
 	process.exit(0);
 }
 
-if (argv.f) {
-	if (!fs.existsSync(argv.f)) {
-		console.error('Error: file not found');
-		process.exit(1);
-	}
-
-	if (isDirectory(argv.f)) {
-		console.error('Error: file expected but directory found');
-		process.exit(1);
-	}
-
-	sql = fs.readFileSync(argv.f, 'utf8').toString();
-	execute(sql, argv._);
-} else {
-	sql = argv._.shift() || '';
-
-	// if data is not piped
-	execute(sql, argv._);
-}
+main();
 
 /**
  * Execute SQL query

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"scripts": {
 		"test": "sh build.sh && yarn test-only",
 		"test-ci": "(yarn test-format-all || 1) && yarn test-only && yarn install-g && alasql 'select 1 as Succes'",
-		"test-only": "node node_modules/mocha/bin/mocha.js ./test --reporter dot",
+		"test-only": "node node_modules/mocha/bin/mocha.js ./test --reporter dot --bail",
 		"#test-only": "(command -v bun && bun node_modules/.bin/mocha ./test --reporter dot) || npx bun node_modules/.bin/mocha ./test --reporter dot",
 		"test-browser": "node test/browserTestRunner.js 7387",
 		"test-cover": "# istanbul cover  -x 'lib/zt/zt.js' --dir test/coverage _mocha",

--- a/src/15utility.js
+++ b/src/15utility.js
@@ -310,7 +310,7 @@ let loadFile = (utils.loadFile = function (path, asy, success, error) {
 		fs = require('fs');
 
 		// If path is empty, than read data from stdin (for Node)
-		if (typeof path === 'undefined') {
+		if ([null, undefined].includes(path)) {
 			var buff = '';
 			process.stdin.setEncoding('utf8');
 			process.stdin.on('readable', function () {

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,0 +1,101 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var {execSync, spawn} = require('child_process');
+	var fs = require('fs');
+	var path = require('path');
+}
+
+describe('Test CLI - Command Line Interface', function () {
+	console.log(__dirname);
+	const cliPath = path.join(__dirname, '..', 'bin', 'alasql-cli.js');
+	const testSqlFile = path.join(__dirname, 'temp-test.sql');
+
+	before(function () {
+		// Create a temporary SQL file for testing
+		fs.writeFileSync(testSqlFile, 'SELECT VALUE 42');
+	});
+
+	after(function () {
+		// Clean up temporary files
+		if (fs.existsSync(testSqlFile)) {
+			fs.unlinkSync(testSqlFile);
+		}
+	});
+
+	it('1. Should execute simple SQL statement', function () {
+		const result = execSync(`node "${cliPath}" "SELECT VALUE 42"`).toString().trim();
+		assert.strictEqual(result, '42');
+	});
+
+	it('2. Should handle parameters', function () {
+		const result = execSync(`node "${cliPath}" "SELECT VALUE ?" 100`).toString().trim();
+		assert.strictEqual(result, '100');
+	});
+
+	it('3. Should execute SQL from file', function () {
+		const result = execSync(`node "${cliPath}" -f "${testSqlFile}"`).toString().trim();
+		assert.strictEqual(result, '42');
+	});
+
+	it('4. Should output minified JSON with -m flag', function () {
+		const result = execSync(`node "${cliPath}" -m "SELECT {a:1,b:2} as obj"`).toString().trim();
+		assert.strictEqual(result, '[{"obj":{"a":1,"b":2}}]');
+	});
+
+	it('5. Should show version with -v flag', function () {
+		const result = execSync(`node "${cliPath}" -v`).toString().trim();
+		assert.match(result, /^\d+\.\d+\.\d+/);
+	});
+
+	it('6. Should output AST with --ast flag', function () {
+		const result = execSync(`node "${cliPath}" --ast "SELECT 1"`).toString().trim();
+		const ast = JSON.parse(result);
+		assert.strictEqual(ast.statements[0].columns[0].value, 1);
+	});
+
+	it('7. Should handle file not found error', function () {
+		try {
+			execSync(`node "${cliPath}" -f "nonexistent.sql"`, {stdio: 'pipe'});
+			assert.fail('Should have thrown an error');
+		} catch (error) {
+			assert.match(error.stderr.toString(), /Error: file not found/);
+		}
+	});
+
+	it('8. Should handle piped input data', function () {
+		const result = execSync(
+			`echo "hello" | node "${cliPath}" "SELECT COUNT(*) > 0 as Success FROM txt()"`
+		).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: true,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('9. Should handle redirected file input', function () {
+		const result = execSync(
+			`node "${cliPath}" "SELECT COUNT(*) > 0 as Success FROM txt()" < ${testSqlFile}`
+		).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: true,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('10. Should handle empty SQL error', function () {
+		try {
+			execSync(`node "${cliPath}" ""`, {stdio: 'pipe'});
+			assert.fail('Should have thrown an error');
+		} catch (error) {
+			assert.match(error.stderr.toString(), /No SQL to process/);
+		}
+	});
+});

--- a/test/test2149-with-txt.sql
+++ b/test/test2149-with-txt.sql
@@ -1,0 +1,1 @@
+SELECT COUNT(*) > 0 as Success FROM txt()

--- a/test/test2149-without-txt.sql
+++ b/test/test2149-without-txt.sql
@@ -1,0 +1,1 @@
+SELECT 1 as Success

--- a/test/test2149.js
+++ b/test/test2149.js
@@ -5,10 +5,12 @@ if (typeof exports === 'object') {
 	var path = require('path');
 }
 
-describe('Test CLI - Command Line Interface', function () {
+describe('Test CLI - Command Line Interface - Issue #2149 (Pipe handling with txt())', function () {
 	console.log(__dirname);
 	const cliPath = path.join(__dirname, '..', 'bin', 'alasql-cli.js');
 	const testSqlFile = path.join(__dirname, 'temp-test.sql');
+	const testWithTxtFile = path.join(__dirname, 'test2149-with-txt.sql');
+	const testWithoutTxtFile = path.join(__dirname, 'test2149-without-txt.sql');
 
 	before(function () {
 		// Create a temporary SQL file for testing
@@ -62,7 +64,7 @@ describe('Test CLI - Command Line Interface', function () {
 		}
 	});
 
-	it('8. Should handle piped input data', function () {
+	it('8. Should handle piped input data with txt() function - Issue #2149', function () {
 		const result = execSync(
 			`echo "hello" | node "${cliPath}" "SELECT COUNT(*) > 0 as Success FROM txt()"`
 		).toString();
@@ -76,7 +78,19 @@ describe('Test CLI - Command Line Interface', function () {
 		);
 	});
 
-	it('9. Should handle redirected file input', function () {
+	it('9. Should handle piped input data without txt() function - backward compatibility', function () {
+		const result = execSync(`echo "SELECT 1 as Success" | node "${cliPath}"`).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: 1,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('10. Should handle redirected file input with txt() function', function () {
 		const result = execSync(
 			`node "${cliPath}" "SELECT COUNT(*) > 0 as Success FROM txt()" < ${testSqlFile}`
 		).toString();
@@ -90,7 +104,61 @@ describe('Test CLI - Command Line Interface', function () {
 		);
 	});
 
-	it('10. Should handle empty SQL error', function () {
+	it('11. Should handle file with txt() function and piped data - Issue #2149', function () {
+		const result = execSync(
+			`echo "hello world" | node "${cliPath}" -f "${testWithTxtFile}"`
+		).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: true,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('12. Should handle file without txt() function normally', function () {
+		const result = execSync(`node "${cliPath}" -f "${testWithoutTxtFile}"`).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: 1,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('13. Should handle piped input to file without txt() function - should be ignored', function () {
+		const result = execSync(
+			`echo "this should be ignored" | node "${cliPath}" -f "${testWithoutTxtFile}"`
+		).toString();
+		assert.deepEqual(
+			[
+				{
+					Success: 1,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('14. Should handle complex SQL with txt() and piped data', function () {
+		const result = execSync(
+			`echo -e "line1\nline2\nline3" | node "${cliPath}" "SELECT COUNT(*) as LineCount FROM txt()"`
+		).toString();
+		assert.deepEqual(
+			[
+				{
+					LineCount: 3,
+				},
+			],
+			JSON.parse(result)
+		);
+	});
+
+	it('15. Should handle empty SQL error', function () {
 		try {
 			execSync(`node "${cliPath}" ""`, {stdio: 'pipe'});
 			assert.fail('Should have thrown an error');


### PR DESCRIPTION
closes:#2149

This PR fixes an issue where piped input was being treated as SQL statements in the AlaSQL CLI, causing parse errors. It also resolves a related Docker issue where commands passed to the container would not execute correctly due to TTY-dependent logic.

Changes:
- Updated the CLI to let alasql.utils.loadFile handle input streams, ensuring piped data is processed correctly.
- Removed TTY-dependent logic so commands now run reliably in Docker and standard terminals.

These changes allow piped input and Docker commands to work as expected without errors.