### PR TITLE
Make `react-native-fs` an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,13 @@
 		"cross-fetch": "4.1.0",
 		"yargs": "16"
 	},
-	"optionalDependencies": {
+	"peerDependencies": {
 		"react-native-fs": "^2.20.0"
+	},
+	"peerDependenciesMeta": {
+		"react-native-fs": {
+			"optional": true
+		}
 	},
 	"devDependencies": {
 		"blueimp-md5": "2.19.0",
@@ -74,6 +79,7 @@
 		"open": "11.0.0",
 		"prettier": "3.8.1",
 		"react-native-fetch-blob": "^0.10.8",
+		"react-native-fs": "^2.20.0",
 		"rexreplace": "7.1.14",
 		"strftime": "0.10.3",
 		"tabletop": "^1.6.2",


### PR DESCRIPTION
So far, `react-native-fs` has been declared under `optionalDependencies`, as alasql will use it if available, but doesn't require it to be there. This relation, however, is that of an optional peer dependency, which is contrary to how `optionalDependencies` works, which is that npm will install it by default. To relieve people from having to use custom logic if they don't want to end up with `react-native-fs`, we turn that package into a peer dependency, and use npm's [peerDependenciesMeta](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta) field to declare it as optional.

Note that this is a breaking change as npm will no longer pull in `react-native-fs` by default.

Fixes: #2454


