### PR TITLE
fix: resolve Promise.all concurrent query collision with identical SQ…

### DIFF
--- a/src/17alasql.js
+++ b/src/17alasql.js
@@ -261,10 +261,11 @@ function cleanupCache(statement) {
 	if (!alasql.options.cache) {
 		return;
 	}
-	// cleanup the table data to prevent storing this information in the SQL cache
-	if (statement && statement.query && statement.query.data) {
-		statement.query.data = [];
-	}
+	// NOTE: Do NOT mutate statement.query.data on the cached statement object.
+	// The compiled statement is shared across concurrent executions via sqlCache.
+	// Mutating it here clears data that another concurrent Promise.all call
+	// may still be reading, causing empty results with no error thrown.
+	// See: https://github.com/AlaSQL/alasql/issues/1953
 }
 
 /**
@@ -284,7 +285,9 @@ alasql.dexec = function (databaseid, sql, params, cb, scope) {
 		let statement = db.sqlCache[hh];
 		// If database structure was not changed since last time return cache
 		if (statement && db.dbversion === statement.dbversion) {
-			var res = statement(params, cb);
+			// Clone params to prevent concurrent executions from sharing
+			// the same params reference when called via Promise.all
+			var res = statement(Array.isArray(params) ? params.slice() : Object.assign({}, params), cb);
 			cleanupCache(statement);
 			return res;
 		}


### PR DESCRIPTION
## Description

Fixes #1953

When two async functions with identical SQL strings were executed 
concurrently via `Promise.all`, no results were returned and no error 
was thrown.

## Root Cause

Two separate issues were working together to cause this bug:

1. **`cleanupCache` mutating shared cached object** — The compiled 
   statement stored in `sqlCache` is shared across concurrent executions. 
   `cleanupCache` was clearing `statement.query.data = []` on this shared 
   object while another concurrent call was still reading it, silently 
   wiping the results.

2. **Shared params reference** — Concurrent executions via `Promise.all` 
   were sharing the same params reference, allowing one call to overwrite 
   another's parameters (`f1`/`f2`).

## Why it was hard to notice

- Running functions **individually** worked fine
- Running with **different SQL strings** (different LIMIT values) worked 
  fine because they got different cache keys
- **No error was thrown** — results were just silently empty
- Only triggered by **concurrent identical SQL strings** via `Promise.all`

## Changes

- `cleanupCache()` — Removed mutation of `statement.query.data` on the 
  shared cached statement object
- `alasql.dexec()` — Clone params before passing to cached statement 
  execution to isolate each concurrent call's parameters

## How to reproduce (before fix)

```js
async function fun1() {
    return await alasql.promise(`select * from xlsx(?)`, ["D:\\a1.xlsx"]);
}
async function fun2() {
    return await alasql.promise(`select * from xlsx(?)`, ["D:\\a2.xlsx"]);
}

// Returns empty, no error thrown
const results = await Promise.all([fun1(), fun2()]);
```

## Testing

- [x] Identical SQL strings in `Promise.all` now return correct results
- [x] Different SQL strings still work as before  
- [x] Sequential (non-concurrent) queries unaffected
- [x] Queries without cache (`alasql.options.cache = false`) unaffected