### PR TITLE
fix: make COALESCE return null instead of undefined

### DIFF
--- a/src/61date.js
+++ b/src/61date.js
@@ -31,7 +31,7 @@ stdfn.COALESCE = function () {
 		if (typeof arguments[i] == 'number' && isNaN(arguments[i])) continue;
 		return arguments[i];
 	}
-	return undefined;
+	return null; // Change this line at the bottom of stdfn.COALESCE
 };
 
 stdfn.USER = function () {

--- a/test/test999.js
+++ b/test/test999.js
@@ -1,0 +1,13 @@
+if (typeof module !== 'undefined' && typeof require !== 'undefined') {
+var alasql = require('../dist/alasql.js');
+}
+
+describe('Test COALESCE bugfix', function () {
+it('Should return NULL if all arguments are null', function () {
+// Pass a JavaScript undefined variable as a parameter ($1)
+var res = alasql('SELECT COALESCE(NULL, $0) AS result', [undefined]);
+if (res[0].result !== null) {
+throw new Error('COALESCE returned undefined instead of null');
+}
+});
+});


### PR DESCRIPTION
Fixes COALESCE to return standard SQL null instead of JavaScript undefined when all arguments are missing or null. Added "test/test999.js" to ensure proper behavior and prevent future regressions.